### PR TITLE
Close mcp client when using agent generation in deployment

### DIFF
--- a/sdk-ts/src/functions/remote.ts
+++ b/sdk-ts/src/functions/remote.ts
@@ -135,6 +135,9 @@ export class RemoteToolkit {
         const mcpToolkit = new MCPToolkit(mcpClient);
         this._mcpToolkit = mcpToolkit;
         await mcpToolkit.initialize();
+        if (this.settings.deploy) {
+          this.modelContextProtocolClient.close();
+        }
       } catch (error) {
         if (this.fallbackUrl) {
           transport = new WebSocketClientTransport(new URL(this.fallbackUrl), {


### PR DESCRIPTION
I've added a close on the mcpClient after usage
I'm not sure it's close at the right time, so you need to review it

At the end it look like working like that, it was stuck during the exec of autogenerated file before that cause the mcpserver connection was never killed