### PR TITLE
feat: improve CLI for AI agent usability (ENG-2297, ENG-2298, ENG-2299)

### DIFF
--- a/cli/apply.go
+++ b/cli/apply.go
@@ -12,6 +12,7 @@ import (
 	"github.com/blaxel-ai/sdk-go/option"
 	"github.com/blaxel-ai/toolkit/cli/core"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func init() {
@@ -163,6 +164,11 @@ via -e flag for .env files or -s flag for command-line secrets.`,
 				}
 			}
 
+			outputFmt := core.GetOutputFormat()
+			if outputFmt == "json" || outputFmt == "yaml" {
+				printApplyStructuredOutput(applyResults, outputFmt, !hasFailures)
+			}
+
 			if hasFailures {
 				core.ExitWithError(fmt.Errorf("one or more resources failed to apply"))
 			}
@@ -253,6 +259,50 @@ func Apply(filePath string, opts ...ApplyOption) ([]ApplyResult, error) {
 	}
 
 	return applyResults, nil
+}
+
+func printApplyStructuredOutput(results []ApplyResult, outputFmt string, success bool) {
+	type applyResourceResult struct {
+		Kind   string `json:"kind"`
+		Name   string `json:"name"`
+		Action string `json:"action"`
+		Error  string `json:"error,omitempty"`
+	}
+
+	type applyOutput struct {
+		Applied []applyResourceResult `json:"applied"`
+		Failed  []applyResourceResult `json:"failed"`
+		Success bool                  `json:"success"`
+	}
+
+	output := applyOutput{
+		Applied: []applyResourceResult{},
+		Failed:  []applyResourceResult{},
+		Success: success,
+	}
+
+	for _, r := range results {
+		entry := applyResourceResult{
+			Kind:   r.Kind,
+			Name:   r.Name,
+			Action: r.Result.Status,
+		}
+		if r.Result.Status == "failed" {
+			entry.Error = r.Result.ErrorMsg
+			output.Failed = append(output.Failed, entry)
+		} else {
+			output.Applied = append(output.Applied, entry)
+		}
+	}
+
+	switch outputFmt {
+	case "json":
+		data, _ := json.MarshalIndent(output, "", "  ")
+		fmt.Println(string(data))
+	case "yaml":
+		data, _ := yaml.Marshal(output)
+		fmt.Print(string(data))
+	}
 }
 
 // handleResourceOperationResult contains both the response and upload URL

--- a/cli/chat.go
+++ b/cli/chat.go
@@ -308,9 +308,8 @@ func SendMessageStream(
 
 	// Check if response is actually streaming
 	contentType := response.Header.Get("Content-Type")
-	connection := response.Header.Get("Connection")
 
-	if !core.IsStreamingResponse(contentType, connection) &&
+	if !core.IsStreamingResponse(contentType) &&
 		!strings.Contains(contentType, "application/json") {
 		// Fall back to reading entire response
 		body, err := io.ReadAll(response.Body)

--- a/cli/chat.go
+++ b/cli/chat.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -311,10 +310,7 @@ func SendMessageStream(
 	contentType := response.Header.Get("Content-Type")
 	connection := response.Header.Get("Connection")
 
-	if connection != "keep-alive" &&
-		!strings.Contains(contentType, "text/event-stream") &&
-		!strings.Contains(contentType, "text/plain") &&
-		!strings.Contains(contentType, "application/x-ndjson") &&
+	if !core.IsStreamingResponse(contentType, connection) &&
 		!strings.Contains(contentType, "application/json") {
 		// Fall back to reading entire response
 		body, err := io.ReadAll(response.Body)
@@ -325,96 +321,7 @@ func SendMessageStream(
 		return nil
 	}
 
-	// Stream the response
-	scanner := bufio.NewScanner(response.Body)
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		// Skip empty lines
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-
-		// Handle Server-Sent Events format
-		if strings.HasPrefix(line, "data: ") {
-			data := strings.TrimPrefix(line, "data: ")
-			if data == "[DONE]" {
-				break
-			}
-
-			// Try to parse as JSON to extract content
-			if strings.HasPrefix(data, "{") && strings.HasSuffix(data, "}") {
-				var streamData map[string]interface{}
-				if err := json.Unmarshal([]byte(data), &streamData); err == nil {
-					// Handle OpenAI-style streaming format
-					if choices, ok := streamData["choices"].([]interface{}); ok && len(choices) > 0 {
-						if choice, ok := choices[0].(map[string]interface{}); ok {
-							if delta, ok := choice["delta"].(map[string]interface{}); ok {
-								if content, ok := delta["content"].(string); ok && content != "" {
-									onChunk(content)
-									continue
-								}
-							}
-						}
-					}
-
-					// Handle other formats - look for common content fields
-					if content, ok := streamData["content"].(string); ok && content != "" {
-						onChunk(content)
-						continue
-					}
-					if text, ok := streamData["text"].(string); ok && text != "" {
-						onChunk(text)
-						continue
-					}
-					if message, ok := streamData["message"].(string); ok && message != "" {
-						onChunk(message)
-						continue
-					}
-				}
-			}
-
-			// If not JSON or no content field found, use raw data
-			onChunk(data)
-		} else if strings.HasPrefix(line, "{") && strings.HasSuffix(line, "}") {
-			// Handle NDJSON format (newline-delimited JSON)
-			var streamData map[string]interface{}
-			if err := json.Unmarshal([]byte(line), &streamData); err == nil {
-				// Similar parsing as above for NDJSON
-				if choices, ok := streamData["choices"].([]interface{}); ok && len(choices) > 0 {
-					if choice, ok := choices[0].(map[string]interface{}); ok {
-						if delta, ok := choice["delta"].(map[string]interface{}); ok {
-							if content, ok := delta["content"].(string); ok && content != "" {
-								onChunk(content)
-								continue
-							}
-						}
-					}
-				}
-
-				if content, ok := streamData["content"].(string); ok && content != "" {
-					onChunk(content)
-					continue
-				}
-				if text, ok := streamData["text"].(string); ok && text != "" {
-					onChunk(text)
-					continue
-				}
-				if message, ok := streamData["message"].(string); ok && message != "" {
-					onChunk(message)
-					continue
-				}
-			}
-
-			// If parsing failed, use the whole line
-			onChunk(line)
-		} else {
-			// Handle plain text streaming
-			onChunk(line + "\n")
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
+	if err := core.ReadSSEStream(response.Body, onChunk); err != nil {
 		return fmt.Errorf("error reading stream: %w", err)
 	}
 

--- a/cli/core/create.go
+++ b/cli/core/create.go
@@ -253,7 +253,6 @@ func PromptTemplateOptions(directory string, templates Templates, resource strin
 		initialFields = append(initialFields, huh.NewSelect[string]().
 			Title("Language").
 			Description("Language to use for your "+resource).
-			Height(5).
 			Options(langOptions...).
 			Value(&options.Language),
 		)
@@ -333,14 +332,17 @@ func PromptTemplateOptions(directory string, templates Templates, resource strin
 			}
 		}).
 		Run()
-	pick := huh.NewForm(huh.NewGroup(
-		huh.NewSelect[string]().
-			Title("Template").
-			Description("Template to use for your " + resource).
-			Height(templateHeight).
-			Options(templateOptions...).
-			Value(&options.TemplateName),
-	))
+	tmplSelect := huh.NewSelect[string]().
+		Title("Template").
+		Description("Template to use for your " + resource).
+		Options(templateOptions...).
+		Value(&options.TemplateName)
+	// Only set Height when there are enough options to need scrolling;
+	// setting Height triggers a huh viewport bug that hides earlier options.
+	if len(templateOptions) > templateHeight {
+		tmplSelect = tmplSelect.Height(templateHeight)
+	}
+	pick := huh.NewForm(huh.NewGroup(tmplSelect))
 	pick.WithTheme(GetHuhTheme())
 	if err := pick.Run(); err != nil {
 		os.Exit(0)

--- a/cli/core/create.go
+++ b/cli/core/create.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"os"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/huh/spinner"
+	"gopkg.in/yaml.v3"
 )
 
 // RandomString generates a random alphanumeric string of the given length.
@@ -105,20 +107,21 @@ func runCreateFlow(
 			fmt.Println("Available templates:")
 			langs := templates.GetLanguages()
 			for _, lang := range langs {
-				names := []string{}
+				hasTemplates := false
 				for _, t := range templates {
 					if t.Language != lang {
 						continue
 					}
+					if !hasTemplates {
+						fmt.Printf("- %s:\n", lang)
+						hasTemplates = true
+					}
 					name := strings.TrimPrefix(templateDisplayName(t), "template-")
-					names = append(names, name)
-				}
-				if len(names) == 0 {
-					continue
-				}
-				fmt.Printf("- %s:\n", lang)
-				for _, n := range names {
-					fmt.Printf("  - %s\n", n)
+					if t.Description != "" {
+						fmt.Printf("  - %-30s %s\n", name, t.Description)
+					} else {
+						fmt.Printf("  - %s\n", name)
+					}
 				}
 			}
 			return
@@ -154,6 +157,26 @@ func runCreateFlow(
 	// Optionally update blaxel.toml (only for those commands that did previously)
 	if cfg.BlaxelTomlResourceType != "" {
 		_ = EditBlaxelTomlInCurrentDir(cfg.BlaxelTomlResourceType, opts.ProjectName, opts.Directory)
+	}
+
+	// If structured output is requested, print JSON/YAML and skip the regular success message
+	outputFmt := GetOutputFormat()
+	if outputFmt == "json" || outputFmt == "yaml" {
+		result := map[string]string{
+			"directory": opts.Directory,
+			"template":  opts.TemplateName,
+			"language":  opts.Language,
+			"type":      cfg.TemplateType,
+		}
+		switch outputFmt {
+		case "json":
+			data, _ := json.MarshalIndent(result, "", "  ")
+			fmt.Println(string(data))
+		case "yaml":
+			data, _ := yaml.Marshal(result)
+			fmt.Print(string(data))
+		}
+		return
 	}
 
 	// Let the caller print specific success instructions

--- a/cli/core/sse.go
+++ b/cli/core/sse.go
@@ -85,8 +85,8 @@ func extractTextFromJSON(data string) string {
 }
 
 // IsStreamingResponse checks if the HTTP response indicates a streaming response
-// based on Content-Type and Connection headers.
-func IsStreamingResponse(contentType string, connection string) bool {
+// based on Content-Type header.
+func IsStreamingResponse(contentType string) bool {
 	return strings.Contains(contentType, "text/event-stream") ||
 		strings.Contains(contentType, "text/plain") ||
 		strings.Contains(contentType, "application/x-ndjson")

--- a/cli/core/sse.go
+++ b/cli/core/sse.go
@@ -1,0 +1,93 @@
+package core
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"strings"
+)
+
+// ReadSSEStream reads Server-Sent Events from an io.Reader, extracting text
+// content from each event and calling onChunk for each piece of text.
+// It handles SSE data: lines, NDJSON, and plain text formats.
+// Returns any scanner error encountered during reading.
+func ReadSSEStream(reader io.Reader, onChunk func(text string)) error {
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		if strings.HasPrefix(line, "data: ") {
+			data := strings.TrimPrefix(line, "data: ")
+			if data == "[DONE]" {
+				break
+			}
+
+			text := extractTextFromJSON(data)
+			if text != "" {
+				onChunk(text)
+				continue
+			}
+
+			onChunk(data)
+		} else if strings.HasPrefix(line, "{") && strings.HasSuffix(line, "}") {
+			// NDJSON format
+			text := extractTextFromJSON(line)
+			if text != "" {
+				onChunk(text)
+				continue
+			}
+			onChunk(line)
+		} else {
+			// Plain text
+			onChunk(line + "\n")
+		}
+	}
+	return scanner.Err()
+}
+
+// extractTextFromJSON tries to extract text content from a JSON object.
+// Supports OpenAI streaming format (choices[0].delta.content) and common
+// content/text/message fields.
+func extractTextFromJSON(data string) string {
+	if !strings.HasPrefix(data, "{") || !strings.HasSuffix(data, "}") {
+		return ""
+	}
+
+	var obj map[string]interface{}
+	if err := json.Unmarshal([]byte(data), &obj); err != nil {
+		return ""
+	}
+
+	// OpenAI-style: choices[0].delta.content
+	if choices, ok := obj["choices"].([]interface{}); ok && len(choices) > 0 {
+		if choice, ok := choices[0].(map[string]interface{}); ok {
+			if delta, ok := choice["delta"].(map[string]interface{}); ok {
+				if content, ok := delta["content"].(string); ok && content != "" {
+					return content
+				}
+			}
+		}
+	}
+
+	// Common content fields
+	for _, key := range []string{"content", "text", "message"} {
+		if val, ok := obj[key].(string); ok && val != "" {
+			return val
+		}
+	}
+
+	return ""
+}
+
+// IsStreamingResponse checks if the HTTP response indicates a streaming response
+// based on Content-Type and Connection headers.
+func IsStreamingResponse(contentType string, connection string) bool {
+	return connection == "keep-alive" ||
+		strings.Contains(contentType, "text/event-stream") ||
+		strings.Contains(contentType, "text/plain") ||
+		strings.Contains(contentType, "application/x-ndjson")
+}

--- a/cli/core/sse.go
+++ b/cli/core/sse.go
@@ -13,6 +13,7 @@ import (
 // Returns any scanner error encountered during reading.
 func ReadSSEStream(reader io.Reader, onChunk func(text string)) error {
 	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 64*1024), 10*1024*1024) // support up to 10 MB per line
 	for scanner.Scan() {
 		line := scanner.Text()
 
@@ -86,8 +87,7 @@ func extractTextFromJSON(data string) string {
 // IsStreamingResponse checks if the HTTP response indicates a streaming response
 // based on Content-Type and Connection headers.
 func IsStreamingResponse(contentType string, connection string) bool {
-	return connection == "keep-alive" ||
-		strings.Contains(contentType, "text/event-stream") ||
+	return strings.Contains(contentType, "text/event-stream") ||
 		strings.Contains(contentType, "text/plain") ||
 		strings.Contains(contentType, "application/x-ndjson")
 }

--- a/cli/core/sse_test.go
+++ b/cli/core/sse_test.go
@@ -162,21 +162,19 @@ data: {"content":"after"}
 func TestIsStreamingResponse(t *testing.T) {
 	tests := []struct {
 		contentType string
-		connection  string
 		expected    bool
 	}{
-		{"text/event-stream", "", true},
-		{"text/event-stream; charset=utf-8", "", true},
-		{"text/plain", "", true},
-		{"application/x-ndjson", "", true},
-		{"application/json", "keep-alive", false},
-		{"application/json", "", false},
+		{"text/event-stream", true},
+		{"text/event-stream; charset=utf-8", true},
+		{"text/plain", true},
+		{"application/x-ndjson", true},
+		{"application/json", false},
 	}
 
 	for _, tt := range tests {
-		got := IsStreamingResponse(tt.contentType, tt.connection)
+		got := IsStreamingResponse(tt.contentType)
 		if got != tt.expected {
-			t.Errorf("IsStreamingResponse(%q, %q) = %v, want %v", tt.contentType, tt.connection, got, tt.expected)
+			t.Errorf("IsStreamingResponse(%q) = %v, want %v", tt.contentType, got, tt.expected)
 		}
 	}
 }

--- a/cli/core/sse_test.go
+++ b/cli/core/sse_test.go
@@ -1,0 +1,213 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReadSSEStream_OpenAIFormat(t *testing.T) {
+	input := `data: {"choices":[{"delta":{"content":"Hello"}}]}
+data: {"choices":[{"delta":{"content":" world"}}]}
+data: [DONE]
+`
+	var chunks []string
+	err := ReadSSEStream(strings.NewReader(input), func(text string) {
+		chunks = append(chunks, text)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(chunks))
+	}
+	if chunks[0] != "Hello" {
+		t.Errorf("expected 'Hello', got %q", chunks[0])
+	}
+	if chunks[1] != " world" {
+		t.Errorf("expected ' world', got %q", chunks[1])
+	}
+}
+
+func TestReadSSEStream_ContentField(t *testing.T) {
+	input := `data: {"content":"chunk1"}
+data: {"content":"chunk2"}
+data: [DONE]
+`
+	var chunks []string
+	err := ReadSSEStream(strings.NewReader(input), func(text string) {
+		chunks = append(chunks, text)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(chunks))
+	}
+	if chunks[0] != "chunk1" || chunks[1] != "chunk2" {
+		t.Errorf("unexpected chunks: %v", chunks)
+	}
+}
+
+func TestReadSSEStream_TextField(t *testing.T) {
+	input := `data: {"text":"hello"}
+data: [DONE]
+`
+	var chunks []string
+	err := ReadSSEStream(strings.NewReader(input), func(text string) {
+		chunks = append(chunks, text)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 1 || chunks[0] != "hello" {
+		t.Errorf("expected ['hello'], got %v", chunks)
+	}
+}
+
+func TestReadSSEStream_RawTextData(t *testing.T) {
+	input := `data: just plain text
+data: more text
+data: [DONE]
+`
+	var chunks []string
+	err := ReadSSEStream(strings.NewReader(input), func(text string) {
+		chunks = append(chunks, text)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(chunks))
+	}
+	if chunks[0] != "just plain text" {
+		t.Errorf("expected 'just plain text', got %q", chunks[0])
+	}
+}
+
+func TestReadSSEStream_NDJSON(t *testing.T) {
+	input := `{"content":"line1"}
+{"content":"line2"}
+`
+	var chunks []string
+	err := ReadSSEStream(strings.NewReader(input), func(text string) {
+		chunks = append(chunks, text)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(chunks))
+	}
+	if chunks[0] != "line1" || chunks[1] != "line2" {
+		t.Errorf("unexpected chunks: %v", chunks)
+	}
+}
+
+func TestReadSSEStream_PlainText(t *testing.T) {
+	input := "Hello world\nSecond line\n"
+	var chunks []string
+	err := ReadSSEStream(strings.NewReader(input), func(text string) {
+		chunks = append(chunks, text)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(chunks))
+	}
+	if chunks[0] != "Hello world\n" {
+		t.Errorf("expected 'Hello world\\n', got %q", chunks[0])
+	}
+}
+
+func TestReadSSEStream_EmptyLines(t *testing.T) {
+	input := `data: {"content":"a"}
+
+data: {"content":"b"}
+
+data: [DONE]
+`
+	var chunks []string
+	err := ReadSSEStream(strings.NewReader(input), func(text string) {
+		chunks = append(chunks, text)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(chunks))
+	}
+}
+
+func TestReadSSEStream_DoneStops(t *testing.T) {
+	input := `data: {"content":"before"}
+data: [DONE]
+data: {"content":"after"}
+`
+	var chunks []string
+	err := ReadSSEStream(strings.NewReader(input), func(text string) {
+		chunks = append(chunks, text)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk (should stop at DONE), got %d", len(chunks))
+	}
+	if chunks[0] != "before" {
+		t.Errorf("expected 'before', got %q", chunks[0])
+	}
+}
+
+func TestIsStreamingResponse(t *testing.T) {
+	tests := []struct {
+		contentType string
+		connection  string
+		expected    bool
+	}{
+		{"text/event-stream", "", true},
+		{"text/event-stream; charset=utf-8", "", true},
+		{"text/plain", "", true},
+		{"application/x-ndjson", "", true},
+		{"application/json", "keep-alive", true},
+		{"application/json", "", false},
+	}
+
+	for _, tt := range tests {
+		got := IsStreamingResponse(tt.contentType, tt.connection)
+		if got != tt.expected {
+			t.Errorf("IsStreamingResponse(%q, %q) = %v, want %v", tt.contentType, tt.connection, got, tt.expected)
+		}
+	}
+}
+
+func TestExtractTextFromJSON_OpenAI(t *testing.T) {
+	input := `{"choices":[{"delta":{"content":"hello"}}]}`
+	result := extractTextFromJSON(input)
+	if result != "hello" {
+		t.Errorf("expected 'hello', got %q", result)
+	}
+}
+
+func TestExtractTextFromJSON_ContentField(t *testing.T) {
+	input := `{"content":"test"}`
+	result := extractTextFromJSON(input)
+	if result != "test" {
+		t.Errorf("expected 'test', got %q", result)
+	}
+}
+
+func TestExtractTextFromJSON_NotJSON(t *testing.T) {
+	result := extractTextFromJSON("not json")
+	if result != "" {
+		t.Errorf("expected empty string, got %q", result)
+	}
+}
+
+func TestExtractTextFromJSON_NoTextField(t *testing.T) {
+	input := `{"id":"123","status":"ok"}`
+	result := extractTextFromJSON(input)
+	if result != "" {
+		t.Errorf("expected empty string, got %q", result)
+	}
+}

--- a/cli/core/sse_test.go
+++ b/cli/core/sse_test.go
@@ -169,7 +169,7 @@ func TestIsStreamingResponse(t *testing.T) {
 		{"text/event-stream; charset=utf-8", "", true},
 		{"text/plain", "", true},
 		{"application/x-ndjson", "", true},
-		{"application/json", "keep-alive", true},
+		{"application/json", "keep-alive", false},
 		{"application/json", "", false},
 	}
 

--- a/cli/core/templates.go
+++ b/cli/core/templates.go
@@ -229,7 +229,7 @@ func findNextAvailablePort(content string) int {
 func (t Templates) GetLanguages() []string {
 	languages := []string{}
 	for _, template := range t {
-		if !slices.Contains(languages, template.Language) {
+		if template.Language != "" && !slices.Contains(languages, template.Language) {
 			languages = append(languages, template.Language)
 		}
 	}

--- a/cli/core/templates_test.go
+++ b/cli/core/templates_test.go
@@ -57,6 +57,34 @@ func TestTemplatesGetLanguages(t *testing.T) {
 	assert.Contains(t, languages, "typescript")
 }
 
+func TestTemplatesGetLanguagesExcludesEmpty(t *testing.T) {
+	templates := Templates{
+		{
+			Template: blaxel.Template{Name: "python-agent"},
+			Language: "python",
+			Type:     "agent",
+		},
+		{
+			Template: blaxel.Template{Name: "no-lang-template"},
+			Language: "",
+			Type:     "agent",
+		},
+		{
+			Template: blaxel.Template{Name: "ts-agent"},
+			Language: "typescript",
+			Type:     "agent",
+		},
+	}
+
+	languages := templates.GetLanguages()
+
+	// Should exclude templates with empty language
+	assert.Len(t, languages, 2)
+	assert.Contains(t, languages, "python")
+	assert.Contains(t, languages, "typescript")
+	assert.NotContains(t, languages, "")
+}
+
 func TestTemplatesFilterByLanguage(t *testing.T) {
 	templates := Templates{
 		{

--- a/cli/core/utils.go
+++ b/cli/core/utils.go
@@ -405,6 +405,13 @@ func Print(message string) {
 		return
 	}
 	message = strings.TrimSuffix(message, "\n")
+	// When structured output is requested, route decorative messages to stderr
+	// so stdout contains only the structured data
+	outputFmt := GetOutputFormat()
+	if outputFmt == "json" || outputFmt == "yaml" {
+		fmt.Fprintln(os.Stderr, message)
+		return
+	}
 	fmt.Println(message)
 }
 

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -99,17 +99,23 @@ separately if needed.`,
 
 			// At this point, results contains all your YAML documents
 			hasFailures := false
+			var deleted []deleteEntry
+			var failed []deleteEntry
 			for _, result := range results {
 				for _, resource := range core.GetResources() {
 					if resource.Kind == result.Kind {
 						name := result.Metadata.(map[string]interface{})["name"].(string)
 						if err := DeleteFn(resource, name); err != nil {
 							hasFailures = true
+							failed = append(failed, deleteEntry{Kind: resource.Kind, Name: name})
+						} else {
+							deleted = append(deleted, deleteEntry{Kind: resource.Kind, Name: name})
 						}
 					}
 				}
 			}
 
+			printDeleteStructuredOutput(deleted, failed)
 			if hasFailures {
 				core.ExitWithError(fmt.Errorf("one or more deletions failed"))
 			}

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 
 	"github.com/blaxel-ai/toolkit/cli/core"
@@ -185,7 +186,7 @@ func DeleteFn(resource *core.Resource, name string) error {
 	if resource.Delete == nil {
 		hint := nestedResourceHint(resource, "delete")
 		err := fmt.Errorf("'bl delete %s' is not supported directly.%s", resource.Singular, hint)
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		return err
 	}
 
@@ -195,7 +196,7 @@ func DeleteFn(resource *core.Resource, name string) error {
 	funcValue := reflect.ValueOf(resource.Delete)
 	if funcValue.Kind() != reflect.Func {
 		err := fmt.Errorf("fn is not a valid function")
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		return err
 	}
 
@@ -228,7 +229,7 @@ func DeleteFn(resource *core.Resource, name string) error {
 	}
 
 	if err, ok := results[1].Interface().(error); ok && err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		return err
 	}
 

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -2,11 +2,13 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 
 	"github.com/blaxel-ai/toolkit/cli/core"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func init() {
@@ -157,11 +159,17 @@ separately if needed.`,
 				}
 
 				hasFailures := false
+				var deleted []deleteEntry
+				var failed []deleteEntry
 				for _, name := range args {
 					if err := DeleteFn(resource, name); err != nil {
 						hasFailures = true
+						failed = append(failed, deleteEntry{Kind: resource.Kind, Name: name})
+					} else {
+						deleted = append(deleted, deleteEntry{Kind: resource.Kind, Name: name})
 					}
 				}
+				printDeleteStructuredOutput(deleted, failed)
 				if hasFailures {
 					core.ExitWithError(fmt.Errorf("one or more deletions failed"))
 				}
@@ -228,4 +236,43 @@ func DeleteFn(resource *core.Resource, name string) error {
 	// Success if we get here without error
 	fmt.Printf("Resource %s:%s deleted\n", resource.Kind, name)
 	return nil
+}
+
+type deleteEntry struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+}
+
+func printDeleteStructuredOutput(deleted []deleteEntry, failed []deleteEntry) {
+	outputFmt := core.GetOutputFormat()
+	if outputFmt != "json" && outputFmt != "yaml" {
+		return
+	}
+
+	type deleteOutput struct {
+		Deleted []deleteEntry `json:"deleted"`
+		Failed  []deleteEntry `json:"failed"`
+		Success bool          `json:"success"`
+	}
+
+	output := deleteOutput{
+		Deleted: deleted,
+		Failed:  failed,
+		Success: len(failed) == 0,
+	}
+	if output.Deleted == nil {
+		output.Deleted = []deleteEntry{}
+	}
+	if output.Failed == nil {
+		output.Failed = []deleteEntry{}
+	}
+
+	switch outputFmt {
+	case "json":
+		data, _ := json.MarshalIndent(output, "", "  ")
+		fmt.Println(string(data))
+	case "yaml":
+		data, _ := yaml.Marshal(output)
+		fmt.Print(string(data))
+	}
 }

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -234,7 +234,10 @@ func DeleteFn(resource *core.Resource, name string) error {
 
 	// The new SDK returns typed responses, not *http.Response
 	// Success if we get here without error
-	fmt.Printf("Resource %s:%s deleted\n", resource.Kind, name)
+	outputFmt := core.GetOutputFormat()
+	if outputFmt != "json" && outputFmt != "yaml" {
+		fmt.Printf("Resource %s:%s deleted\n", resource.Kind, name)
+	}
 	return nil
 }
 

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -118,6 +118,16 @@ all projects in a monorepo (looks for blaxel.toml in subdirectories).`,
 			}
 
 			core.SetInteractiveMode(!noTTY)
+
+			// Detect structured output early, before any handleConfigWarning or
+			// interactive prompts, so that warning text never lands on stdout.
+			outputFmt := core.GetOutputFormat()
+			isStructured := outputFmt == "json" || outputFmt == "yaml"
+			if isStructured {
+				noTTY = true
+				core.SetInteractiveMode(false)
+			}
+
 			if folder != "" {
 				recursive = false
 				core.ReadSecrets("", envFiles)
@@ -209,16 +219,6 @@ all projects in a monorepo (looks for blaxel.toml in subdirectories).`,
 					serverEnvWarning := core.BuildServerEnvWarning(language, config.Type)
 					handleConfigWarning(serverEnvWarning, noTTY)
 				}
-			}
-
-			outputFmt := core.GetOutputFormat()
-			isStructured := outputFmt == "json" || outputFmt == "yaml"
-
-			// Force non-interactive mode for structured output before Generate(),
-			// so volume-template tar creation uses the correct mode
-			if isStructured {
-				noTTY = true
-				core.SetInteractiveMode(false)
 			}
 
 			if recursive {
@@ -352,8 +352,8 @@ func (d *Deployment) Generate(skipBuild bool) error {
 
 // handleConfigWarning displays a warning and asks for confirmation in interactive mode
 func handleConfigWarning(warning string, noTTY bool) {
-	// Print the warning
-	fmt.Println(warning)
+	// Route warning to stderr so it never pollutes structured JSON/YAML output
+	fmt.Fprintln(os.Stderr, warning)
 
 	// In non-interactive mode, just show warning and continue
 	if noTTY {
@@ -815,7 +815,18 @@ func (d *Deployment) Apply() error {
 				fmt.Printf("Uploading %s...\n", resourceLabel)
 			}
 
-			err := d.Upload(result.Result.UploadURL)
+			err := d.UploadWithRetry(result.Result.UploadURL, func() (string, error) {
+				newResults, err := ApplyResources(d.blaxelDeployments)
+				if err != nil {
+					return "", err
+				}
+				for _, r := range newResults {
+					if r.Kind == result.Kind && r.Name == result.Name && r.Result.UploadURL != "" {
+						return r.Result.UploadURL, nil
+					}
+				}
+				return "", fmt.Errorf("no upload URL returned on retry")
+			})
 			if err != nil {
 				return fmt.Errorf("failed to upload file: %w", err)
 			}
@@ -1161,7 +1172,16 @@ func (d *Deployment) deployResourceInteractive(resource *deploy.Resource, model 
 			model.AddBuildLog(idx, "Uploading code to registry...")
 		}
 
-		err := d.Upload(applyResults[0].Result.UploadURL)
+		err := d.UploadWithRetry(applyResults[0].Result.UploadURL, func() (string, error) {
+			newResults, applyErr := ApplyResources([]core.Result{deployment})
+			if applyErr != nil {
+				return "", applyErr
+			}
+			if len(newResults) > 0 && newResults[0].Result.UploadURL != "" {
+				return newResults[0].Result.UploadURL, nil
+			}
+			return "", fmt.Errorf("no upload URL returned on retry")
+		})
 		if err != nil {
 			model.UpdateResource(idx, deploy.StatusFailed, "Upload failed", err)
 			model.AddBuildLog(idx, fmt.Sprintf("Upload failed: %v", err))
@@ -1507,9 +1527,17 @@ func (d *Deployment) printStructuredOutput(outputFmt string, startTime time.Time
 		TotalDuration: duration,
 	}
 
-	resourceStatus := "DEPLOYED"
+	resourceStatus := "UNKNOWN"
 	if failed {
 		resourceStatus = "FAILED"
+	} else {
+		// Wait briefly for the backend to update the resource status
+		time.Sleep(200 * time.Millisecond)
+		if status, err := getResourceStatus(config.Type, d.name); err == nil {
+			resourceStatus = status
+		} else {
+			resourceStatus = "DEPLOYING"
+		}
 	}
 
 	res := deployResourceResult{
@@ -1598,6 +1626,33 @@ func (pr *progressReader) Read(p []byte) (int, error) {
 		pr.callback(pr.read, pr.total)
 	}
 	return n, err
+}
+
+// UploadWithRetry attempts the upload up to 5 times with exponential backoff.
+// On each retry it calls refreshURL to re-apply the resource and obtain a fresh
+// presigned URL, since the previous one becomes invalid after a failed attempt.
+func (d *Deployment) UploadWithRetry(url string, refreshURL func() (string, error)) error {
+	const maxRetries = 5
+
+	currentURL := url
+	var lastErr error
+	for attempt := range maxRetries {
+		if attempt > 0 {
+			backoff := time.Duration(1<<uint(attempt-1)) * time.Second
+			time.Sleep(backoff)
+			newURL, err := refreshURL()
+			if err != nil {
+				lastErr = fmt.Errorf("failed to refresh upload URL: %w", err)
+				continue
+			}
+			currentURL = newURL
+		}
+		lastErr = d.Upload(currentURL)
+		if lastErr == nil {
+			return nil
+		}
+	}
+	return lastErr
 }
 
 func (d *Deployment) Upload(url string) error {

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -24,6 +24,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func init() {
@@ -233,19 +234,36 @@ all projects in a monorepo (looks for blaxel.toml in subdirectories).`,
 				return
 			}
 
+			outputFmt := core.GetOutputFormat()
+			isStructured := outputFmt == "json" || outputFmt == "yaml"
+
+			// Force non-interactive mode for structured output
+			if isStructured {
+				noTTY = true
+				core.SetInteractiveMode(false)
+			}
+
+			startTime := time.Now()
+
 			if !noTTY {
 				err = deployment.ApplyInteractive()
 			} else {
 				err = deployment.Apply()
 			}
-			if err != nil {
+
+			deployFailed := err != nil
+			if deployFailed && !isStructured {
 				err = fmt.Errorf("error applying blaxel deployment: %w", err)
 				core.PrintError("Deploy", err)
 				core.ExitWithError(err)
 			}
 
-			// Only show success message for non-interactive deployments
-			if noTTY {
+			if isStructured {
+				deployment.printStructuredOutput(outputFmt, startTime, deployFailed, err)
+				if deployFailed {
+					core.ExitWithError(err)
+				}
+			} else if noTTY {
 				deployment.Ready()
 			}
 		},
@@ -1446,6 +1464,57 @@ func (d *Deployment) deployAdditionalResource(resource *deploy.Resource, model *
 		// If we can't find/apply the resource, just mark as complete
 		model.UpdateResource(idx, deploy.StatusComplete, "Applied successfully", nil)
 		model.AddBuildLog(idx, "Resource marked as complete")
+	}
+}
+
+func (d *Deployment) printStructuredOutput(outputFmt string, startTime time.Time, failed bool, deployErr error) {
+	config := core.GetConfig()
+	duration := time.Since(startTime).Round(time.Second).String()
+
+	type deployResourceResult struct {
+		Kind   string `json:"kind"`
+		Name   string `json:"name"`
+		Status string `json:"status"`
+		URL    string `json:"url,omitempty"`
+		Error  string `json:"error,omitempty"`
+	}
+
+	type deployResult struct {
+		Resources     []deployResourceResult `json:"resources"`
+		Success       bool                   `json:"success"`
+		TotalDuration string                 `json:"totalDuration"`
+	}
+
+	result := deployResult{
+		Success:       !failed,
+		TotalDuration: duration,
+	}
+
+	resourceStatus := "DEPLOYED"
+	if failed {
+		resourceStatus = "FAILED"
+	}
+
+	res := deployResourceResult{
+		Kind:   config.Type,
+		Name:   d.name,
+		Status: resourceStatus,
+	}
+	if d.metadataURL != "" {
+		res.URL = d.metadataURL
+	}
+	if failed && deployErr != nil {
+		res.Error = deployErr.Error()
+	}
+	result.Resources = append(result.Resources, res)
+
+	switch outputFmt {
+	case "json":
+		data, _ := json.MarshalIndent(result, "", "  ")
+		fmt.Println(string(data))
+	case "yaml":
+		data, _ := yaml.Marshal(result)
+		fmt.Print(string(data))
 	}
 }
 

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -1506,6 +1506,9 @@ func (d *Deployment) deployAdditionalResource(resource *deploy.Resource, model *
 
 func (d *Deployment) printStructuredOutput(outputFmt string, startTime time.Time, failed bool, deployErr error) {
 	config := core.GetConfig()
+	if config.Type == "" {
+		config.Type = "unknown"
+	}
 	duration := time.Since(startTime).Round(time.Second).String()
 
 	type deployResourceResult struct {

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -211,6 +211,16 @@ all projects in a monorepo (looks for blaxel.toml in subdirectories).`,
 				}
 			}
 
+			outputFmt := core.GetOutputFormat()
+			isStructured := outputFmt == "json" || outputFmt == "yaml"
+
+			// Force non-interactive mode for structured output before Generate(),
+			// so volume-template tar creation uses the correct mode
+			if isStructured {
+				noTTY = true
+				core.SetInteractiveMode(false)
+			}
+
 			if recursive {
 				if deployPackage(dryRun, name) {
 					return
@@ -234,15 +244,6 @@ all projects in a monorepo (looks for blaxel.toml in subdirectories).`,
 				return
 			}
 
-			outputFmt := core.GetOutputFormat()
-			isStructured := outputFmt == "json" || outputFmt == "yaml"
-
-			// Force non-interactive mode for structured output
-			if isStructured {
-				noTTY = true
-				core.SetInteractiveMode(false)
-			}
-
 			startTime := time.Now()
 
 			if !noTTY {
@@ -252,10 +253,12 @@ all projects in a monorepo (looks for blaxel.toml in subdirectories).`,
 			}
 
 			deployFailed := err != nil
-			if deployFailed && !isStructured {
+			if deployFailed {
 				err = fmt.Errorf("error applying blaxel deployment: %w", err)
-				core.PrintError("Deploy", err)
-				core.ExitWithError(err)
+				if !isStructured {
+					core.PrintError("Deploy", err)
+					core.ExitWithError(err)
+				}
 			}
 
 			if isStructured {
@@ -323,12 +326,18 @@ func (d *Deployment) Generate(skipBuild bool) error {
 			// For interactive mode, skip compression here - it will be done during deployment
 			// to show progress to the user
 			if !core.IsInteractiveMode() {
-				fmt.Println("Compressing volume template files...")
+				outputFmt := core.GetOutputFormat()
+				isStructured := outputFmt == "json" || outputFmt == "yaml"
+				if !isStructured {
+					fmt.Println("Compressing volume template files...")
+				}
 				err = d.Tar()
 				if err != nil {
 					return fmt.Errorf("failed to tar file: %w", err)
 				}
-				fmt.Println("Compression completed")
+				if !isStructured {
+					fmt.Println("Compression completed")
+				}
 			}
 		} else {
 			err = d.Zip()
@@ -747,9 +756,14 @@ func getResourceStatus(resourceType, name string) (string, error) {
 }
 
 func (d *Deployment) Apply() error {
+	outputFmt := core.GetOutputFormat()
+	isStructured := outputFmt == "json" || outputFmt == "yaml"
+
 	blaxelDir := filepath.Join(d.cwd, ".blaxel")
 	if _, err := os.Stat(blaxelDir); err == nil {
-		fmt.Println("Applying additional resources from .blaxel directory...")
+		if !isStructured {
+			fmt.Println("Applying additional resources from .blaxel directory...")
+		}
 		_, err = Apply(blaxelDir, WithRecursive(true))
 		if err != nil {
 			return fmt.Errorf("failed to apply .blaxel directory: %w", err)
@@ -783,28 +797,31 @@ func (d *Deployment) Apply() error {
 
 	for _, result := range applyResults {
 		if result.Result.UploadURL != "" {
-			config := core.GetConfig()
-			// Print upload message for all resource types
-			resourceLabel := "code"
-			switch strings.ToLower(config.Type) {
-			case "volumetemplate":
-				resourceLabel = "volume template"
-			case "agent":
-				resourceLabel = "agent code"
-			case "function":
-				resourceLabel = "function code"
-			case "job":
-				resourceLabel = "job code"
-			case "sandbox":
-				resourceLabel = "sandbox code"
+			if !isStructured {
+				config := core.GetConfig()
+				resourceLabel := "code"
+				switch strings.ToLower(config.Type) {
+				case "volumetemplate":
+					resourceLabel = "volume template"
+				case "agent":
+					resourceLabel = "agent code"
+				case "function":
+					resourceLabel = "function code"
+				case "job":
+					resourceLabel = "job code"
+				case "sandbox":
+					resourceLabel = "sandbox code"
+				}
+				fmt.Printf("Uploading %s...\n", resourceLabel)
 			}
-			fmt.Printf("Uploading %s...\n", resourceLabel)
 
 			err := d.Upload(result.Result.UploadURL)
 			if err != nil {
 				return fmt.Errorf("failed to upload file: %w", err)
 			}
-			fmt.Println("Upload completed")
+			if !isStructured {
+				fmt.Println("Upload completed")
+			}
 		}
 	}
 

--- a/cli/get.go
+++ b/cli/get.go
@@ -14,9 +14,12 @@ import (
 	"syscall"
 	"time"
 
+	blaxel "github.com/blaxel-ai/sdk-go"
 	"github.com/blaxel-ai/toolkit/cli/core"
+	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
+	"gopkg.in/yaml.v3"
 )
 
 func init() {
@@ -40,6 +43,11 @@ A "resource" in Blaxel refers to any deployable or manageable entity:
 - policies: Access control policies
 - volumes: Persistent storage
 - integrationconnections: External service integrations
+
+Hub Discovery (pre-built resources available in the Blaxel Hub):
+- sandbox-hub: Pre-built sandbox images with pre-installed tools and runtimes
+- mcp-hub: Pre-built MCP servers for tool integrations (GitHub, Slack, etc.)
+- templates: Project scaffolding templates for bl new
 
 Output Formats:
 Use -o flag to control output format:
@@ -83,6 +91,14 @@ The command can list all resources of a type or get details for a specific one.`
 
   # Get specific execution for a job
   bl get job my-job execution EXECUTION_ID
+
+  # List pre-built sandbox images from the Hub
+  bl get sandbox-hub
+  bl get sandbox-hub -o json
+
+  # List pre-built MCP servers from the Hub
+  bl get mcp-hub
+  bl get mcp-hub -o json
 
   # Monitor sandbox status
   bl get sandbox my-sandbox --watch
@@ -247,6 +263,10 @@ The command can list all resources of a type or get details for a specific one.`
 	// Add templates subcommand (non-CRUD, fetches from GitHub API)
 	cmd.AddCommand(getTemplatesCmd())
 
+	// Add hub subcommands (pre-built definitions from Blaxel Hub)
+	cmd.AddCommand(getSandboxHubCmd())
+	cmd.AddCommand(getMCPHubCmd())
+
 	cmd.PersistentFlags().BoolVarP(&watch, "watch", "", false, "After listing/getting the requested object, watch for changes.")
 	return cmd
 }
@@ -285,6 +305,203 @@ Output formats:
 			listAvailableTemplates(filterType, core.GetOutputFormat())
 		},
 	}
+}
+
+func getSandboxHubCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "sandbox-hub",
+		Short:   "List pre-built sandbox images available in the Blaxel Hub",
+		Aliases: []string{"sbx-hub", "sandbox-images"},
+		Args:    cobra.NoArgs,
+		Long: `List pre-built sandbox images from the Blaxel Hub.
+
+Each image comes with pre-installed tools, runtimes, and configurations.
+Use the 'image' field value in your sandbox YAML spec when deploying
+with 'bl apply -f sandbox.yaml':
+
+  apiVersion: blaxel/v1alpha1
+  kind: Sandbox
+  metadata:
+    name: my-sandbox
+  spec:
+    image: <image-from-hub>
+
+Output formats:
+  -o json   Machine-readable JSON array
+  -o yaml   YAML output
+  default   Table with NAME, IMAGE, MEMORY, DESCRIPTION columns`,
+		Example: `  # List all available sandbox hub images
+  bl get sandbox-hub
+
+  # List as JSON (for automation/agents)
+  bl get sandbox-hub -o json
+
+  # List as YAML
+  bl get sandbox-hub -o yaml`,
+		Run: func(cmd *cobra.Command, args []string) {
+			client := core.GetClient()
+			if client == nil {
+				core.PrintError("Sandbox Hub", fmt.Errorf("client not initialized, please log in with 'bl login'"))
+				core.ExitWithError(fmt.Errorf("client not initialized"))
+			}
+			resp, err := client.Sandboxes.GetHub(context.Background())
+			if err != nil {
+				core.PrintError("Sandbox Hub", err)
+				core.ExitWithError(err)
+			}
+
+			// Filter out hidden and coming-soon images
+			var images []blaxel.SandboxGetHubResponse
+			if resp != nil {
+				for _, img := range *resp {
+					if !img.Hidden && !img.ComingSoon {
+						images = append(images, img)
+					}
+				}
+			}
+
+			if len(images) == 0 {
+				core.PrintInfo("No sandbox hub images found")
+				return
+			}
+
+			outputFmt := core.GetOutputFormat()
+			switch outputFmt {
+			case "json":
+				data, _ := json.MarshalIndent(images, "", "  ")
+				fmt.Println(string(data))
+			case "yaml":
+				yamlData, _ := yaml.Marshal(images)
+				fmt.Print(string(yamlData))
+			default:
+				printSandboxHubTable(images)
+			}
+		},
+	}
+}
+
+func printSandboxHubTable(images []blaxel.SandboxGetHubResponse) {
+	tw := table.NewWriter()
+	tw.SetStyle(table.StyleLight)
+	tw.AppendHeader(table.Row{"NAME", "IMAGE", "MEMORY (MB)", "DESCRIPTION"})
+	for _, img := range images {
+		name := img.DisplayName
+		if name == "" {
+			name = img.Name
+		}
+		desc := img.Description
+		if len(desc) > 50 {
+			desc = desc[:47] + "..."
+		}
+		tw.AppendRow(table.Row{name, img.Image, img.Memory, desc})
+	}
+	fmt.Println(tw.Render())
+}
+
+// mcpHubDefinition represents a pre-built MCP server from the Blaxel Hub.
+// The Go SDK does not yet expose GET /mcp/hub, so we call it via client.Get.
+type mcpHubDefinition struct {
+	Name        string `json:"name" yaml:"name"`
+	DisplayName string `json:"displayName" yaml:"displayName"`
+	Image       string `json:"image" yaml:"image"`
+	Description string `json:"description" yaml:"description"`
+	Integration string `json:"integration,omitempty" yaml:"integration,omitempty"`
+	Icon        string `json:"icon,omitempty" yaml:"icon,omitempty"`
+	Hidden      bool   `json:"hidden" yaml:"hidden"`
+	ComingSoon  bool   `json:"coming_soon" yaml:"coming_soon"`
+	Enterprise  bool   `json:"enterprise" yaml:"enterprise"`
+	Transport   string `json:"transport,omitempty" yaml:"transport,omitempty"`
+}
+
+func getMCPHubCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "mcp-hub",
+		Short:   "List pre-built MCP servers available in the Blaxel Hub",
+		Aliases: []string{"function-hub"},
+		Args:    cobra.NoArgs,
+		Long: `List pre-built MCP servers from the Blaxel Hub.
+
+These provide ready-to-use tool integrations (e.g. GitHub, Slack,
+databases). Connect one to your agent by creating an integration
+connection with 'bl apply -f connection.yaml':
+
+  apiVersion: blaxel/v1alpha1
+  kind: IntegrationConnection
+  metadata:
+    name: my-github
+  spec:
+    integration: <integration-from-hub>
+
+Output formats:
+  -o json   Machine-readable JSON array
+  -o yaml   YAML output
+  default   Table with NAME, INTEGRATION, DESCRIPTION columns`,
+		Example: `  # List all available MCP hub servers
+  bl get mcp-hub
+
+  # List as JSON (for automation/agents)
+  bl get mcp-hub -o json
+
+  # List as YAML
+  bl get mcp-hub -o yaml`,
+		Run: func(cmd *cobra.Command, args []string) {
+			client := core.GetClient()
+			if client == nil {
+				core.PrintError("MCP Hub", fmt.Errorf("client not initialized, please log in with 'bl login'"))
+				core.ExitWithError(fmt.Errorf("client not initialized"))
+			}
+
+			var resp []mcpHubDefinition
+			err := client.Get(context.Background(), "mcp/hub", nil, &resp)
+			if err != nil {
+				core.PrintError("MCP Hub", err)
+				core.ExitWithError(err)
+			}
+
+			// Filter out hidden and coming-soon entries
+			var definitions []mcpHubDefinition
+			for _, d := range resp {
+				if !d.Hidden && !d.ComingSoon {
+					definitions = append(definitions, d)
+				}
+			}
+
+			if len(definitions) == 0 {
+				core.PrintInfo("No MCP hub servers found")
+				return
+			}
+
+			outputFmt := core.GetOutputFormat()
+			switch outputFmt {
+			case "json":
+				data, _ := json.MarshalIndent(definitions, "", "  ")
+				fmt.Println(string(data))
+			case "yaml":
+				yamlData, _ := yaml.Marshal(definitions)
+				fmt.Print(string(yamlData))
+			default:
+				printMCPHubTable(definitions)
+			}
+		},
+	}
+}
+
+func printMCPHubTable(definitions []mcpHubDefinition) {
+	tw := table.NewWriter()
+	tw.SetStyle(table.StyleLight)
+	tw.AppendHeader(table.Row{"NAME", "INTEGRATION", "DESCRIPTION"})
+	for _, d := range definitions {
+		name := d.DisplayName
+		if name == "" {
+			name = d.Name
+		}
+		desc := d.Description
+		if len(desc) > 60 {
+			desc = desc[:57] + "..."
+		}
+		tw.AppendRow(table.Row{name, d.Integration, desc})
+	}
+	fmt.Println(tw.Render())
 }
 
 func GetFn(resource *core.Resource, name string) {

--- a/cli/get.go
+++ b/cli/get.go
@@ -243,8 +243,48 @@ The command can list all resources of a type or get details for a specific one.`
 
 		cmd.AddCommand(subcmd)
 	}
+
+	// Add templates subcommand (non-CRUD, fetches from GitHub API)
+	cmd.AddCommand(getTemplatesCmd())
+
 	cmd.PersistentFlags().BoolVarP(&watch, "watch", "", false, "After listing/getting the requested object, watch for changes.")
 	return cmd
+}
+
+func getTemplatesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "templates [type]",
+		Short:   "List available project templates",
+		Aliases: []string{"template", "tpl"},
+		Args:    cobra.MaximumNArgs(1),
+		Long: `List available templates that can be used with 'bl new'.
+
+Templates are grouped by type (agent, mcp, sandbox, job, volume-template).
+Use an optional type argument to filter results.
+
+Output formats:
+  -o json   Machine-readable JSON array
+  -o yaml   YAML output
+  default   Table with NAME, TYPE, LANGUAGE, DESCRIPTION columns`,
+		Example: `  # List all templates
+  bl get templates
+
+  # List agent templates only
+  bl get templates agent
+
+  # List templates as JSON
+  bl get templates -o json
+
+  # List MCP templates
+  bl get templates mcp`,
+		Run: func(cmd *cobra.Command, args []string) {
+			filterType := ""
+			if len(args) == 1 {
+				filterType = args[0]
+			}
+			listAvailableTemplates(filterType, core.GetOutputFormat())
+		},
+	}
 }
 
 func GetFn(resource *core.Resource, name string) {

--- a/cli/new.go
+++ b/cli/new.go
@@ -1,12 +1,16 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/blaxel-ai/toolkit/cli/core"
 	"github.com/charmbracelet/huh"
+	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 type newType string
@@ -36,6 +40,7 @@ func init() {
 func NewCmd() *cobra.Command {
 	var templateName string
 	var noTTY bool
+	var listTemplates bool
 
 	cmd := &cobra.Command{
 		Use:               "new [type] [directory]",
@@ -63,6 +68,10 @@ Resource Types:
   volumetemplate - Pre-configured volume template for creating volumes
               		Use cases: Persistent storage templates, data volume configurations
 
+Template Discovery:
+Use --list to see all available templates with descriptions before creating.
+Combine with a type argument to filter: 'bl new agent --list'
+
 Interactive Mode (Recommended):
 When called without arguments, the CLI guides you through:
 1. Choosing a resource type
@@ -80,6 +89,19 @@ After Creation:
 4. Test it works as expected
 5. Deploy to Blaxel with 'bl deploy'`,
 		Run: func(cmd *cobra.Command, args []string) {
+			// Handle --list flag
+			if listTemplates {
+				filterType := ""
+				if len(args) >= 1 {
+					t := parseNewType(args[0])
+					if t != "" {
+						filterType = string(t)
+					}
+				}
+				listAvailableTemplates(filterType, core.GetOutputFormat())
+				return
+			}
+
 			var t newType
 			dirArg := ""
 
@@ -138,6 +160,7 @@ After Creation:
 
 	cmd.Flags().StringVarP(&templateName, "template", "t", "", "Template to use (skips interactive prompt)")
 	cmd.Flags().BoolVarP(&noTTY, "yes", "y", false, "Skip interactive prompts and use defaults")
+	cmd.Flags().BoolVarP(&listTemplates, "list", "l", false, "List available templates with descriptions")
 
 	cmd.Example = `  # Interactive creation (recommended for beginners)
   bl new
@@ -153,6 +176,15 @@ After Creation:
 
   # Create job with specific template
   bl new job my-batch-job -t jobs-py
+
+  # List all available templates
+  bl new --list
+
+  # List agent templates only
+  bl new agent --list
+
+  # List templates as JSON (for machine parsing)
+  bl new --list -o json
 
   # Full workflow example:
   bl new agent my-assistant
@@ -178,4 +210,74 @@ func parseNewType(s string) newType {
 	default:
 		return ""
 	}
+}
+
+type templateInfo struct {
+	Name        string `json:"name"`
+	FullName    string `json:"fullName"`
+	Type        string `json:"type"`
+	Language    string `json:"language"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+}
+
+// listAvailableTemplates retrieves and displays templates in the requested format.
+// filterType narrows results to a specific template type (e.g. "agent", "mcp").
+func listAvailableTemplates(filterType string, outputFormat string) {
+	types := []string{"agent", "mcp", "sandbox", "job", "volume-template"}
+	if filterType != "" {
+		types = []string{filterType}
+	}
+
+	stripRe := regexp.MustCompile(`^\d+-`)
+
+	var results []templateInfo
+	for _, t := range types {
+		templates, err := core.RetrieveTemplates(t)
+		if err != nil {
+			continue
+		}
+		for _, tmpl := range templates {
+			displayName := stripRe.ReplaceAllString(tmpl.Name, "")
+			displayName = strings.TrimPrefix(displayName, "template-")
+			results = append(results, templateInfo{
+				Name:        displayName,
+				FullName:    tmpl.Name,
+				Type:        t,
+				Language:    tmpl.Language,
+				Description: tmpl.Description,
+				URL:         tmpl.URL,
+			})
+		}
+	}
+
+	if len(results) == 0 {
+		core.PrintInfo("No templates found")
+		return
+	}
+
+	switch outputFormat {
+	case "json":
+		data, _ := json.MarshalIndent(results, "", "  ")
+		fmt.Println(string(data))
+	case "yaml":
+		data, _ := yaml.Marshal(results)
+		fmt.Print(string(data))
+	default:
+		printTemplateTable(results)
+	}
+}
+
+func printTemplateTable(templates []templateInfo) {
+	t := table.NewWriter()
+	t.SetStyle(table.StyleLight)
+	t.AppendHeader(table.Row{"NAME", "TYPE", "LANGUAGE", "DESCRIPTION"})
+	for _, tmpl := range templates {
+		desc := tmpl.Description
+		if len(desc) > 60 {
+			desc = desc[:57] + "..."
+		}
+		t.AppendRow(table.Row{tmpl.Name, tmpl.Type, tmpl.Language, desc})
+	}
+	fmt.Println(t.Render())
 }

--- a/cli/new.go
+++ b/cli/new.go
@@ -95,7 +95,7 @@ After Creation:
 				if len(args) >= 1 {
 					t := parseNewType(args[0])
 					if t != "" {
-						filterType = string(t)
+						filterType = newTypeToTemplateKey(t)
 					}
 				}
 				listAvailableTemplates(filterType, core.GetOutputFormat())
@@ -212,6 +212,14 @@ func parseNewType(s string) newType {
 	}
 }
 
+// newTypeToTemplateKey maps a newType to the template topic key used by RetrieveTemplates.
+func newTypeToTemplateKey(t newType) string {
+	if t == newTypeVolumeTemplate {
+		return "volume-template"
+	}
+	return string(t)
+}
+
 type templateInfo struct {
 	Name        string `json:"name"`
 	FullName    string `json:"fullName"`
@@ -232,9 +240,11 @@ func listAvailableTemplates(filterType string, outputFormat string) {
 	stripRe := regexp.MustCompile(`^\d+-`)
 
 	var results []templateInfo
+	var lastErr error
 	for _, t := range types {
 		templates, err := core.RetrieveTemplates(t)
 		if err != nil {
+			lastErr = err
 			continue
 		}
 		for _, tmpl := range templates {
@@ -252,7 +262,11 @@ func listAvailableTemplates(filterType string, outputFormat string) {
 	}
 
 	if len(results) == 0 {
-		core.PrintInfo("No templates found")
+		if lastErr != nil {
+			core.PrintError("Templates", fmt.Errorf("failed to retrieve templates: %w", lastErr))
+		} else {
+			core.PrintInfo("No templates found")
+		}
 		return
 	}
 

--- a/cli/push.go
+++ b/cli/push.go
@@ -261,7 +261,23 @@ You must run this command from a directory containing a blaxel.toml file.`,
 
 				// Upload the archive to the presigned URL
 				fmt.Println("Uploading source code...")
-				err = deployment.Upload(uploadURL)
+				err = deployment.UploadWithRetry(uploadURL, func() (string, error) {
+					var retryResp *http.Response
+					var retryBody createImageResponse
+					retryErr := client.Post(ctx, "images", reqBody, &retryBody,
+						option.WithResponseInto(&retryResp),
+						option.WithQuery("upload", "true"),
+					)
+					if retryErr != nil {
+						return "", retryErr
+					}
+					if retryResp != nil {
+						if u := retryResp.Header.Get("X-Blaxel-Upload-Url"); u != "" {
+							return u, nil
+						}
+					}
+					return "", fmt.Errorf("no upload URL returned from server")
+				})
 				if err != nil {
 					core.PrintError("Push", fmt.Errorf("failed to upload source code: %w", err))
 					core.ExitWithError(err)

--- a/cli/run.go
+++ b/cli/run.go
@@ -290,8 +290,7 @@ This is useful for testing specific endpoints or non-standard API calls.`,
 
 			// Detect streaming response
 			contentType := res.Header.Get("Content-Type")
-			connection := res.Header.Get("Connection")
-			isSSE := core.IsStreamingResponse(contentType, connection)
+			isSSE := core.IsStreamingResponse(contentType)
 
 			if isSSE || stream {
 				// Handle streaming response

--- a/cli/run.go
+++ b/cli/run.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	blaxel "github.com/blaxel-ai/sdk-go"
 	"github.com/blaxel-ai/sdk-go/option"
@@ -46,7 +47,8 @@ func RunCmd() *cobra.Command {
 	var commandSecrets []string
 	var folder string
 	var concurrent int
-	var outputFormat string
+	var stream bool
+	var timeout int
 	cmd := &cobra.Command{
 		Use:               "run resource-type resource-name",
 		Args:              cobra.ExactArgs(2),
@@ -79,6 +81,11 @@ Input Formats:
 - Inline JSON with --data json-object
 - From file with --file path/to/input.json
 
+Streaming:
+When agents respond via SSE (Server-Sent Events), the CLI automatically detects
+and parses the stream. Use --stream to explicitly request streaming mode and
+print chunks in real-time as they arrive.
+
 Advanced Usage:
 Use --path, --method, and --params for custom HTTP requests to your resources.
 This is useful for testing specific endpoints or non-standard API calls.`,
@@ -87,6 +94,12 @@ This is useful for testing specific endpoints or non-standard API calls.`,
 
   # Run agent with file input
   bl run agent my-agent --file request.json
+
+  # Run agent with real-time streaming output
+  bl run agent my-agent --data '{"inputs": "hello"}' --stream
+
+  # Run agent with timeout
+  bl run agent my-agent --data '{"inputs": "hello"}' --timeout 120
 
   # Run job with batch file
   bl run job my-job --file batches/process-users.json
@@ -108,6 +121,9 @@ This is useful for testing specific endpoints or non-standard API calls.`,
 
   # Debug mode (see full request/response details)
   bl run agent my-agent --data '{}' --debug
+
+  # Get JSON output for machine parsing
+  bl run agent my-agent --data '{"inputs": "hello"}' -o json
 
   # Execute a command in a sandbox
   bl run sandbox my-sandbox --path /process --data '{"command": "echo hello"}'
@@ -135,6 +151,7 @@ This is useful for testing specific endpoints or non-standard API calls.`,
 			resourceType := args[0]
 			resourceName := args[1]
 			headers := make(map[string]string)
+			outputFormat := core.GetOutputFormat()
 
 			// Parse header flags into map
 			for _, header := range headerFlags {
@@ -216,9 +233,23 @@ This is useful for testing specific endpoints or non-standard API calls.`,
 				resourceType = "sandbox"
 			}
 
+			// Add streaming headers when --stream flag is set
+			if stream {
+				headers["Accept"] = "text/event-stream"
+				headers["Cache-Control"] = "no-cache"
+			}
+
+			// Set up context with optional timeout
+			ctx := context.Background()
+			if timeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+				defer cancel()
+			}
+
 			workspace := core.GetWorkspace()
 			res, err := runRequest(
-				context.Background(),
+				ctx,
 				workspace,
 				resourceType,
 				resourceName,
@@ -232,19 +263,16 @@ This is useful for testing specific endpoints or non-standard API calls.`,
 				port,
 			)
 			if err != nil {
-				err = fmt.Errorf("error making request: %w", err)
+				if ctx.Err() == context.DeadlineExceeded {
+					err = fmt.Errorf("request timed out after %ds", timeout)
+				} else {
+					err = fmt.Errorf("error making request: %w", err)
+				}
 				core.PrintError("Run", err)
 				core.ExitWithError(err)
 			}
 			defer func() { _ = res.Body.Close() }()
 
-			// Read response body
-			body, err := io.ReadAll(res.Body)
-			if err != nil {
-				err = fmt.Errorf("error reading response: %w", err)
-				core.PrintError("Run", err)
-				core.ExitWithError(err)
-			}
 			// Only print status code if it's an error
 			if res.StatusCode >= 400 {
 				core.PrintError("Run", fmt.Errorf("response status: %s", res.Status))
@@ -260,62 +288,102 @@ This is useful for testing specific endpoints or non-standard API calls.`,
 				fmt.Println()
 			}
 
-			// Handle job-specific success output (skip if raw output format)
-			if isJob && res.StatusCode < 400 && !isRawOutput {
-				// Try to extract execution_id from response for the log command hint
-				var responseData map[string]interface{}
-				executionID := ""
-				if err := json.Unmarshal(body, &responseData); err == nil {
-					if id, ok := responseData["execution_id"].(string); ok {
-						executionID = id
-					} else if id, ok := responseData["executionId"].(string); ok {
-						executionID = id
-					} else if id, ok := responseData["id"].(string); ok {
-						executionID = id
+			// Detect streaming response
+			contentType := res.Header.Get("Content-Type")
+			connection := res.Header.Get("Connection")
+			isSSE := core.IsStreamingResponse(contentType, connection)
+
+			if isSSE || stream {
+				// Handle streaming response
+				var accumulated strings.Builder
+				err := core.ReadSSEStream(res.Body, func(chunk string) {
+					if isRawOutput {
+						accumulated.WriteString(chunk)
+					} else {
+						fmt.Print(chunk)
+						accumulated.WriteString(chunk)
 					}
+				})
+				if err != nil {
+					if ctx.Err() == context.DeadlineExceeded {
+						err = fmt.Errorf("request timed out after %ds", timeout)
+					}
+					core.PrintError("Run", fmt.Errorf("error reading stream: %w", err))
+					core.ExitWithError(err)
+				}
+				// Final newline for non-raw modes
+				if !isRawOutput && accumulated.Len() > 0 {
+					fmt.Println()
+				}
+				// For JSON output, wrap the accumulated text
+				if outputFormat == "json" {
+					result := map[string]string{"output": accumulated.String()}
+					jsonData, _ := json.MarshalIndent(result, "", "  ")
+					fmt.Println(string(jsonData))
+				} else if outputFormat == "yaml" {
+					result := map[string]string{"output": accumulated.String()}
+					yamlData, _ := yaml.Marshal(result)
+					fmt.Print(string(yamlData))
+				}
+			} else {
+				// Non-streaming: read full body
+				body, err := io.ReadAll(res.Body)
+				if err != nil {
+					err = fmt.Errorf("error reading response: %w", err)
+					core.PrintError("Run", err)
+					core.ExitWithError(err)
 				}
 
-				// Print monitor logs hint with command in white
-				if executionID != "" {
-					// Show short execution ID (first 8 chars) for readability
-					shortID := executionID
-					if len(shortID) > 8 {
-						shortID = shortID[:8]
+				// Handle job-specific success output (skip if raw output format)
+				if isJob && res.StatusCode < 400 && !isRawOutput {
+					var responseData map[string]interface{}
+					executionID := ""
+					if err := json.Unmarshal(body, &responseData); err == nil {
+						if id, ok := responseData["execution_id"].(string); ok {
+							executionID = id
+						} else if id, ok := responseData["executionId"].(string); ok {
+							executionID = id
+						} else if id, ok := responseData["id"].(string); ok {
+							executionID = id
+						}
 					}
-					core.PrintInfoWithCommand("Logs:", fmt.Sprintf("bl logs job %s %s -f", resourceName, shortID))
-				} else {
-					core.PrintInfoWithCommand("Logs:", fmt.Sprintf("bl logs job %s -f", resourceName))
-				}
-				core.PrintSuccess(fmt.Sprintf("Job '%s' execution started successfully!", resourceName))
-				fmt.Println()
-			}
 
-			// Output based on format
-			switch outputFormat {
-			case "json":
-				// Raw JSON output
-				fmt.Println(string(body))
-			case "yaml":
-				// Convert JSON to YAML
-				var jsonData interface{}
-				if err := json.Unmarshal(body, &jsonData); err == nil {
-					yamlBytes, err := yaml.Marshal(jsonData)
-					if err == nil {
-						fmt.Print(string(yamlBytes))
+					if executionID != "" {
+						shortID := executionID
+						if len(shortID) > 8 {
+							shortID = shortID[:8]
+						}
+						core.PrintInfoWithCommand("Logs:", fmt.Sprintf("bl logs job %s %s -f", resourceName, shortID))
+					} else {
+						core.PrintInfoWithCommand("Logs:", fmt.Sprintf("bl logs job %s -f", resourceName))
+					}
+					core.PrintSuccess(fmt.Sprintf("Job '%s' execution started successfully!", resourceName))
+					fmt.Println()
+				}
+
+				// Output based on format
+				switch outputFormat {
+				case "json":
+					fmt.Println(string(body))
+				case "yaml":
+					var jsonData interface{}
+					if err := json.Unmarshal(body, &jsonData); err == nil {
+						yamlBytes, err := yaml.Marshal(jsonData)
+						if err == nil {
+							fmt.Print(string(yamlBytes))
+						} else {
+							fmt.Println(string(body))
+						}
 					} else {
 						fmt.Println(string(body))
 					}
-				} else {
-					fmt.Println(string(body))
-				}
-			default:
-				// Pretty print JSON response
-				var prettyJSON bytes.Buffer
-				if err := json.Indent(&prettyJSON, body, "", "  "); err == nil {
-					core.Print(prettyJSON.String())
-				} else {
-					// If not JSON, print as string
-					core.Print(string(body))
+				default:
+					var prettyJSON bytes.Buffer
+					if err := json.Indent(&prettyJSON, body, "", "  "); err == nil {
+						core.Print(prettyJSON.String())
+					} else {
+						core.Print(string(body))
+					}
 				}
 			}
 		},
@@ -335,7 +403,8 @@ This is useful for testing specific endpoints or non-standard API calls.`,
 	cmd.Flags().StringSliceVarP(&commandSecrets, "secrets", "s", []string{}, "Secrets to pass to the execution")
 	cmd.Flags().StringVar(&folder, "directory", "", "Directory to run the command from")
 	cmd.Flags().IntVarP(&concurrent, "concurrent", "c", 1, "Number of concurrent workers for local job execution")
-	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format: json, yaml")
+	cmd.Flags().BoolVar(&stream, "stream", false, "Stream SSE responses in real-time")
+	cmd.Flags().IntVar(&timeout, "timeout", 0, "Request timeout in seconds (default: no timeout)")
 	return cmd
 }
 

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -63,9 +63,15 @@ func TestRunCmd(t *testing.T) {
 	dirFlag := cmd.Flags().Lookup("directory")
 	assert.NotNil(t, dirFlag)
 
-	outputFlag := cmd.Flags().Lookup("output")
-	assert.NotNil(t, outputFlag)
-	assert.Equal(t, "o", outputFlag.Shorthand)
+	// --output is now the global persistent flag from root (not local to run)
+	// Verify the new --stream and --timeout flags
+	streamFlag := cmd.Flags().Lookup("stream")
+	assert.NotNil(t, streamFlag)
+	assert.Equal(t, "false", streamFlag.DefValue)
+
+	timeoutFlag := cmd.Flags().Lookup("timeout")
+	assert.NotNil(t, timeoutFlag)
+	assert.Equal(t, "0", timeoutFlag.DefValue)
 }
 
 func TestBatchStruct(t *testing.T) {


### PR DESCRIPTION
## Summary

- **ENG-2297**: Add template discoverability via `bl get templates [type]` and `bl new --list` flag. Templates now show descriptions in listings and error messages.
- **ENG-2298**: Fix SSE streaming in `bl run` -- auto-detects `text/event-stream` responses, adds `--stream` flag for real-time output, `--timeout` flag for request timeouts. Extracts shared SSE parser from `chat.go` into reusable `core/sse.go`.
- **ENG-2299**: Add consistent `--output json/yaml` across `deploy`, `apply`, `new`, `delete` commands. Removes `bl run`'s local `--output` flag that shadowed the global one. Routes decorative output to stderr when structured output is active.

## Linear

Closes ENG-2297
Closes ENG-2298
Closes ENG-2299

## Changes

**New files (2):**
- `cli/core/sse.go` -- shared SSE parsing (ReadSSEStream, IsStreamingResponse, ExtractTextFromJSON)
- `cli/core/sse_test.go` -- 10 tests covering OpenAI format, raw text, NDJSON, DONE sentinel

**Modified files (10):**
- `cli/run.go` -- SSE auto-detection, --stream, --timeout, removed local --output flag
- `cli/chat.go` -- refactored to use shared core.ReadSSEStream (-90 lines)
- `cli/new.go` -- --list flag, listAvailableTemplates(), printTemplateTable()
- `cli/get.go` -- `bl get templates` subcommand
- `cli/core/create.go` -- enhanced error messages with descriptions, JSON output for bl new
- `cli/core/utils.go` -- route decorative output to stderr in JSON mode
- `cli/deploy.go` -- JSON/YAML structured output for deploy results
- `cli/apply.go` -- JSON/YAML structured output for apply results
- `cli/delete.go` -- JSON/YAML structured output for delete results
- `cli/run_test.go` -- updated tests for new flags

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test -count=1 ./...` all pass
- [x] SSE parsing tests cover OpenAI format, raw text, NDJSON, plain text, DONE sentinel
- [x] Manual: `bl get templates` lists templates with descriptions
- [x] Manual: `bl new --list` shows templates
- [x] Manual: `bl run agent <name> --data '{...}'` displays SSE streamed response
- [x] Manual: `bl run agent <name> --stream --data '{...}'` shows real-time chunks
- [ ] Manual: `bl deploy -o json -y` outputs structured JSON
- [ ] Manual: `bl get agents -o json` still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/toolkit/pull/274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR adds three CLI features: template discoverability (`bl get templates`, `bl new --list`), SSE streaming improvements in `bl run` with a shared parser extracted to `core/sse.go`, and consistent `--output json/yaml` across deploy/apply/new/delete commands. The latest commits also add `bl get sandbox-hub`/`bl get mcp-hub`, `UploadWithRetry` with presigned URL refresh, and early structured-output detection to suppress interactive prompts.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit db9efc9a127743b48a7faba0f64c2578ec730d69.</sup>
<!-- /MENDRAL_SUMMARY -->