### PR TITLE
Hotfix documentation

### DIFF
--- a/cli/get.go
+++ b/cli/get.go
@@ -319,12 +319,14 @@ Each image comes with pre-installed tools, runtimes, and configurations.
 Use the 'image' field value in your sandbox YAML spec when deploying
 with 'bl apply -f sandbox.yaml':
 
+` + "```yaml" + `
   apiVersion: blaxel/v1alpha1
   kind: Sandbox
   metadata:
     name: my-sandbox
   spec:
     image: <image-from-hub>
+` + "```" + `
 
 Output formats:
   -o json   Machine-readable JSON array
@@ -425,12 +427,14 @@ These provide ready-to-use tool integrations (e.g. GitHub, Slack,
 databases). Connect one to your agent by creating an integration
 connection with 'bl apply -f connection.yaml':
 
+` + "```yaml" + `
   apiVersion: blaxel/v1alpha1
   kind: IntegrationConnection
   metadata:
     name: my-github
   spec:
     integration: <integration-from-hub>
+` + "```" + `
 
 Output formats:
   -o json   Machine-readable JSON array

--- a/docs/bl_deploy.md
+++ b/docs/bl_deploy.md
@@ -84,6 +84,7 @@ bl deploy [flags]
   -c, --registry-cred stringArray   Registry credentials (format: registry=username:password, repeatable)
   -s, --secrets strings             Secrets to deploy
       --skip-build                  Skip the build step
+      --timeout string              Timeout for build and deployment monitoring (e.g. 30m, 1h). Defaults to 15m
   -t, --type string                 Resource type (sandbox, agent, function, job). Defaults to blaxel.toml type or 'sandbox'
   -y, --yes                         Skip interactive mode
 ```

--- a/docs/bl_get_mcp-hub.md
+++ b/docs/bl_get_mcp-hub.md
@@ -14,12 +14,14 @@ These provide ready-to-use tool integrations (e.g. GitHub, Slack,
 databases). Connect one to your agent by creating an integration
 connection with 'bl apply -f connection.yaml':
 
+```yaml
   apiVersion: blaxel/v1alpha1
   kind: IntegrationConnection
   metadata:
     name: my-github
   spec:
     integration: <integration-from-hub>
+```
 
 Output formats:
   -o json   Machine-readable JSON array

--- a/docs/bl_get_sandbox-hub.md
+++ b/docs/bl_get_sandbox-hub.md
@@ -14,12 +14,14 @@ Each image comes with pre-installed tools, runtimes, and configurations.
 Use the 'image' field value in your sandbox YAML spec when deploying
 with 'bl apply -f sandbox.yaml':
 
+```yaml
   apiVersion: blaxel/v1alpha1
   kind: Sandbox
   metadata:
     name: my-sandbox
   spec:
     image: <image-from-hub>
+```
 
 Output formats:
   -o json   Machine-readable JSON array

--- a/docs/bl_push.md
+++ b/docs/bl_push.md
@@ -41,6 +41,9 @@ bl push [flags]
 
   # Push specifying a resource type
   bl push --type agent
+
+  # Push with a longer timeout for large images
+  bl push --timeout 30m
 ```
 
 ### Options
@@ -51,6 +54,7 @@ bl push [flags]
   -h, --help                        help for push
   -n, --name string                 Name for the image (defaults to directory name)
   -c, --registry-cred stringArray   Registry credentials (format: registry=username:password, repeatable)
+      --timeout string              Timeout for build log monitoring (e.g. 30m, 1h). Defaults to 15m
   -t, --type string                 Resource type (agent, function, sandbox, job). Defaults to blaxel.toml type; required if not set
   -y, --yes                         Skip interactive mode
 ```


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/toolkit/pull/282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds YAML code fences to sandbox-hub and mcp-hub help text in both the Go CLI source and generated markdown docs, and documents the new `--timeout` flag for `bl deploy` and `bl push` commands.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit a968c76e31000c4371e8acfc7b5c5c21175c2023.</sup>
<!-- /MENDRAL_SUMMARY -->