### PR TITLE
feat(ENG-2372): improve PowerShell installer reliability and add CI smoke tests

### DIFF
--- a/.github/workflows/test-install-ps1.yaml
+++ b/.github/workflows/test-install-ps1.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "install.ps1"
+      - ".github/workflows/test-install-ps1.yaml"
 
 jobs:
   test-install-ps1:
@@ -49,3 +50,45 @@ jobs:
         shell: pwsh
         run: |
           bl version
+
+      - name: Verify Git-missing warning appears when git is absent
+        shell: pwsh
+        run: |
+          # Reinstall in a child PowerShell with PATH stripped of any git location
+          # to assert that the install script surfaces the "Git was not found" hint.
+          $filteredPath = ($env:Path -split ';' | Where-Object {
+            $_ -and -not (Test-Path (Join-Path $_ 'git.exe'))
+          }) -join ';'
+          $output = & pwsh -NoProfile -Command {
+            param($p)
+            $env:Path = $p
+            & .\install.ps1 2>&1
+          } -args $filteredPath
+          $joined = ($output | Out-String)
+          if ($joined -notmatch 'Git was not found') {
+            Write-Error "Expected 'Git was not found' warning in output but got:`n$joined"
+            exit 1
+          }
+          Write-Host "Git-missing warning is correctly surfaced."
+
+      - name: Login with API key and verify workspace access
+        shell: pwsh
+        env:
+          BL_API_KEY: ${{ secrets.BL_API_KEY }}
+          BL_WORKSPACE: ${{ secrets.BL_WORKSPACE }}
+        run: |
+          if ([string]::IsNullOrEmpty($env:BL_API_KEY) -or [string]::IsNullOrEmpty($env:BL_WORKSPACE)) {
+            Write-Host "BL_API_KEY or BL_WORKSPACE secret not set; skipping login smoke test."
+            exit 0
+          }
+          bl login $env:BL_WORKSPACE
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "bl login failed with exit code $LASTEXITCODE"
+            exit 1
+          }
+          bl workspaces
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "bl workspaces failed with exit code $LASTEXITCODE"
+            exit 1
+          }
+          Write-Host "Login + workspace listing succeeded."

--- a/install.ps1
+++ b/install.ps1
@@ -135,9 +135,42 @@ else {
     $env:Path = "$InstallDir;$env:Path"
 }
 
+# Broadcast WM_SETTINGCHANGE so newly spawned processes (e.g. from Explorer)
+# pick up the updated user PATH without requiring a logout.
+try {
+    if (-not ('NativeMethods.Win32EnvBroadcast' -as [type])) {
+        Add-Type -Namespace NativeMethods -Name Win32EnvBroadcast -MemberDefinition @'
+[System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
+public static extern System.IntPtr SendMessageTimeout(
+    System.IntPtr hWnd, uint Msg, System.UIntPtr wParam, string lParam,
+    uint fuFlags, uint uTimeout, out System.UIntPtr lpdwResult);
+'@ -ErrorAction Stop
+    }
+    $HWND_BROADCAST = [IntPtr]0xffff
+    $WM_SETTINGCHANGE = 0x1A
+    [System.UIntPtr]$result = [System.UIntPtr]::Zero
+    [void][NativeMethods.Win32EnvBroadcast]::SendMessageTimeout(
+        $HWND_BROADCAST, $WM_SETTINGCHANGE, [System.UIntPtr]::Zero, "Environment",
+        2, 5000, [ref]$result)
+}
+catch {
+    # Best-effort; PATH is still persisted via SetEnvironmentVariable above.
+}
+
+# ── Check optional dependencies ──────────────────────────────────────
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Write-Host ""
+    Write-Host "Note: Git was not found on your PATH." -ForegroundColor Yellow
+    Write-Host "Some 'bl' commands (like 'bl new') require Git to be installed." -ForegroundColor Yellow
+    Write-Host "Install it from: https://git-scm.com/download/win" -ForegroundColor Yellow
+}
+
 # ── Done ─────────────────────────────────────────────────────────────
 Write-Host ""
 Write-Host "blaxel and bl were installed successfully to $InstallDir"
 Write-Host "Installed version: $Version"
 Write-Host ""
-Write-Host "To get started, run: bl --help"
+Write-Host "Open a NEW terminal window for 'bl' to be available on your PATH." -ForegroundColor Cyan
+Write-Host "(Already-open terminals will not pick up the updated PATH.)"
+Write-Host ""
+Write-Host "Then run: bl --help"


### PR DESCRIPTION
## Summary

Follow-up to #286 addressing Vikram's feedback after end-to-end testing on a fresh Windows 11 VM.

- Broadcast `WM_SETTINGCHANGE` from `install.ps1` so new processes spawned from Explorer pick up the updated user PATH without requiring a logout.
- Detect missing `git` and surface a yellow warning pointing to git-scm.com (required for `bl new`).
- Replace the misleading "To get started, run: bl --help" with an explicit "open a new terminal window" message, since already-open shells cannot inherit the new PATH.
- Extend the GH workflow:
  - Reinstall in a child pwsh with PATH stripped of any `git.exe` location and assert the Git-missing warning is emitted.
  - Optional `bl login` + `bl workspaces` smoke test gated on `BL_API_KEY` and `BL_WORKSPACE` repo secrets (skips cleanly if not set).
- Trigger the workflow when the workflow file itself changes.

Refs ENG-2372

## Test plan

- [ ] CI green on `windows-latest` runner.
- [ ] Git-missing warning step asserts the message in the install output.
- [ ] Once `BL_API_KEY` + `BL_WORKSPACE` secrets are configured, the login step runs `bl login` non-interactively and `bl workspaces` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/toolkit/pull/287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Improves the PowerShell installer by broadcasting `WM_SETTINGCHANGE` after PATH updates, adding a Git-missing warning, and clarifying the "open a new terminal" message. Extends the CI workflow with a Git-absence assertion test and an optional `bl login` + `bl workspaces` smoke test gated on repo secrets.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 6b133a044795e2d29e73a69bc649a242ce87a25d.</sup>
<!-- /MENDRAL_SUMMARY -->