### PR TITLE
Devin/1777513574 build env support

### DIFF
--- a/cli/core/buildenv.go
+++ b/cli/core/buildenv.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 )
 
-// ReadBuildEnv reads a .build-env file and returns a map of KEY=VALUE pairs.
+// ReadBuildEnv reads a .env.build file and returns a map of KEY=VALUE pairs.
 // If customPath is non-empty, it is used as the file path (error if missing).
-// If customPath is empty, it looks for .build-env in projectDir (silently skips if missing).
+// If customPath is empty, it looks for .env.build in projectDir (silently skips if missing).
 // Lines starting with # and blank lines are skipped.
 // Empty values (KEY=) are valid.
 func ReadBuildEnv(projectDir string, customPath string) (map[string]string, error) {
@@ -25,7 +25,7 @@ func ReadBuildEnv(projectDir string, customPath string) (map[string]string, erro
 		}
 		required = true
 	} else {
-		filePath = filepath.Join(projectDir, ".build-env")
+		filePath = filepath.Join(projectDir, ".env.build")
 		required = false
 	}
 
@@ -35,9 +35,9 @@ func ReadBuildEnv(projectDir string, customPath string) (map[string]string, erro
 			return nil, nil
 		}
 		if os.IsNotExist(err) && required {
-			return nil, fmt.Errorf("build-env file not found: %s", filePath)
+			return nil, fmt.Errorf(".env.build file not found: %s", filePath)
 		}
-		return nil, fmt.Errorf("failed to read build-env file: %w", err)
+		return nil, fmt.Errorf("failed to read .env.build file: %w", err)
 	}
 
 	return parseBuildEnv(string(content))
@@ -59,21 +59,21 @@ func parseBuildEnv(content string) (map[string]string, error) {
 
 		eqIdx := strings.Index(line, "=")
 		if eqIdx < 0 {
-			return nil, fmt.Errorf(".build-env line %d: invalid format (expected KEY=VALUE): %s", lineNum, line)
+			return nil, fmt.Errorf(".env.build line %d: invalid format (expected KEY=VALUE): %s", lineNum, line)
 		}
 
 		key := strings.TrimSpace(line[:eqIdx])
 		value := strings.TrimSpace(line[eqIdx+1:])
 
 		if key == "" {
-			return nil, fmt.Errorf(".build-env line %d: empty key", lineNum)
+			return nil, fmt.Errorf(".env.build line %d: empty key", lineNum)
 		}
 
 		args[key] = value
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("failed to parse .build-env: %w", err)
+		return nil, fmt.Errorf("failed to parse .env.build: %w", err)
 	}
 
 	if len(args) == 0 {
@@ -83,8 +83,8 @@ func parseBuildEnv(content string) (map[string]string, error) {
 	return args, nil
 }
 
-// MergeBuildEnvContent merges build args from blaxel.toml [build.args] and .build-env file content.
-// The .build-env content takes precedence on duplicate keys.
+// MergeBuildEnvContent merges build args from blaxel.toml [build.args] and .env.build file content.
+// The .env.build content takes precedence on duplicate keys.
 // Returns the merged content as KEY=VALUE lines suitable for injection into the archive,
 // and the number of unique merged args.
 func MergeBuildEnvContent(tomlArgs map[string]string, envArgs map[string]string) ([]byte, int) {
@@ -99,7 +99,7 @@ func MergeBuildEnvContent(tomlArgs map[string]string, envArgs map[string]string)
 		merged[k] = v
 	}
 
-	// Override with .build-env args
+	// Override with .env.build args
 	for k, v := range envArgs {
 		merged[k] = v
 	}

--- a/cli/core/buildenv.go
+++ b/cli/core/buildenv.go
@@ -85,10 +85,11 @@ func parseBuildEnv(content string) (map[string]string, error) {
 
 // MergeBuildEnvContent merges build args from blaxel.toml [build.args] and .build-env file content.
 // The .build-env content takes precedence on duplicate keys.
-// Returns the merged content as KEY=VALUE lines suitable for injection into the archive.
-func MergeBuildEnvContent(tomlArgs map[string]string, envArgs map[string]string) []byte {
+// Returns the merged content as KEY=VALUE lines suitable for injection into the archive,
+// and the number of unique merged args.
+func MergeBuildEnvContent(tomlArgs map[string]string, envArgs map[string]string) ([]byte, int) {
 	if len(tomlArgs) == 0 && len(envArgs) == 0 {
-		return nil
+		return nil, 0
 	}
 
 	merged := make(map[string]string)
@@ -104,7 +105,7 @@ func MergeBuildEnvContent(tomlArgs map[string]string, envArgs map[string]string)
 	}
 
 	if len(merged) == 0 {
-		return nil
+		return nil, 0
 	}
 
 	// Serialize to KEY=VALUE format
@@ -113,5 +114,5 @@ func MergeBuildEnvContent(tomlArgs map[string]string, envArgs map[string]string)
 		lines = append(lines, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	return []byte(strings.Join(lines, "\n") + "\n")
+	return []byte(strings.Join(lines, "\n") + "\n"), len(merged)
 }

--- a/cli/core/buildenv.go
+++ b/cli/core/buildenv.go
@@ -1,0 +1,117 @@
+package core
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ReadBuildEnv reads a .build-env file and returns a map of KEY=VALUE pairs.
+// If customPath is non-empty, it is used as the file path (error if missing).
+// If customPath is empty, it looks for .build-env in projectDir (silently skips if missing).
+// Lines starting with # and blank lines are skipped.
+// Empty values (KEY=) are valid.
+func ReadBuildEnv(projectDir string, customPath string) (map[string]string, error) {
+	var filePath string
+	var required bool
+
+	if customPath != "" {
+		if filepath.IsAbs(customPath) {
+			filePath = customPath
+		} else {
+			filePath = filepath.Join(projectDir, customPath)
+		}
+		required = true
+	} else {
+		filePath = filepath.Join(projectDir, ".build-env")
+		required = false
+	}
+
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) && !required {
+			return nil, nil
+		}
+		if os.IsNotExist(err) && required {
+			return nil, fmt.Errorf("build-env file not found: %s", filePath)
+		}
+		return nil, fmt.Errorf("failed to read build-env file: %w", err)
+	}
+
+	return parseBuildEnv(string(content))
+}
+
+// parseBuildEnv parses KEY=VALUE content. Skips blank lines and # comments.
+func parseBuildEnv(content string) (map[string]string, error) {
+	args := make(map[string]string)
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	lineNum := 0
+
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		eqIdx := strings.Index(line, "=")
+		if eqIdx < 0 {
+			return nil, fmt.Errorf(".build-env line %d: invalid format (expected KEY=VALUE): %s", lineNum, line)
+		}
+
+		key := strings.TrimSpace(line[:eqIdx])
+		value := strings.TrimSpace(line[eqIdx+1:])
+
+		if key == "" {
+			return nil, fmt.Errorf(".build-env line %d: empty key", lineNum)
+		}
+
+		args[key] = value
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to parse .build-env: %w", err)
+	}
+
+	if len(args) == 0 {
+		return nil, nil
+	}
+
+	return args, nil
+}
+
+// MergeBuildEnvContent merges build args from blaxel.toml [build.args] and .build-env file content.
+// The .build-env content takes precedence on duplicate keys.
+// Returns the merged content as KEY=VALUE lines suitable for injection into the archive.
+func MergeBuildEnvContent(tomlArgs map[string]string, envArgs map[string]string) []byte {
+	if len(tomlArgs) == 0 && len(envArgs) == 0 {
+		return nil
+	}
+
+	merged := make(map[string]string)
+
+	// Start with toml args
+	for k, v := range tomlArgs {
+		merged[k] = v
+	}
+
+	// Override with .build-env args
+	for k, v := range envArgs {
+		merged[k] = v
+	}
+
+	if len(merged) == 0 {
+		return nil
+	}
+
+	// Serialize to KEY=VALUE format
+	var lines []string
+	for k, v := range merged {
+		lines = append(lines, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return []byte(strings.Join(lines, "\n") + "\n")
+}

--- a/cli/core/buildenv_test.go
+++ b/cli/core/buildenv_test.go
@@ -70,7 +70,7 @@ func TestReadBuildEnvDefaultMissing(t *testing.T) {
 
 func TestReadBuildEnvDefaultExists(t *testing.T) {
 	dir := t.TempDir()
-	err := os.WriteFile(filepath.Join(dir, ".build-env"), []byte("FOO=bar\n"), 0644)
+	err := os.WriteFile(filepath.Join(dir, ".env.build"), []byte("FOO=bar\n"), 0644)
 	require.NoError(t, err)
 
 	args, err := ReadBuildEnv(dir, "")
@@ -80,17 +80,17 @@ func TestReadBuildEnvDefaultExists(t *testing.T) {
 
 func TestReadBuildEnvCustomPathMissing(t *testing.T) {
 	dir := t.TempDir()
-	_, err := ReadBuildEnv(dir, ".build-env.production")
+	_, err := ReadBuildEnv(dir, ".env.build.production")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
 
 func TestReadBuildEnvCustomPathExists(t *testing.T) {
 	dir := t.TempDir()
-	err := os.WriteFile(filepath.Join(dir, ".build-env.production"), []byte("NODE_ENV=production\n"), 0644)
+	err := os.WriteFile(filepath.Join(dir, ".env.build.production"), []byte("NODE_ENV=production\n"), 0644)
 	require.NoError(t, err)
 
-	args, err := ReadBuildEnv(dir, ".build-env.production")
+	args, err := ReadBuildEnv(dir, ".env.build.production")
 	require.NoError(t, err)
 	assert.Equal(t, "production", args["NODE_ENV"])
 }
@@ -108,7 +108,7 @@ func TestMergeBuildEnvContent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "production", parsed["NODE_ENV"])
 	assert.Equal(t, "secret", parsed["TOKEN"])
-	assert.Equal(t, "from-env", parsed["SHARED"]) // .build-env wins
+	assert.Equal(t, "from-env", parsed["SHARED"]) // .env.build wins
 }
 
 func TestMergeBuildEnvContentBothNil(t *testing.T) {

--- a/cli/core/buildenv_test.go
+++ b/cli/core/buildenv_test.go
@@ -99,8 +99,9 @@ func TestMergeBuildEnvContent(t *testing.T) {
 	tomlArgs := map[string]string{"NODE_ENV": "production", "SHARED": "from-toml"}
 	envArgs := map[string]string{"TOKEN": "secret", "SHARED": "from-env"}
 
-	result := MergeBuildEnvContent(tomlArgs, envArgs)
+	result, count := MergeBuildEnvContent(tomlArgs, envArgs)
 	assert.NotNil(t, result)
+	assert.Equal(t, 3, count) // NODE_ENV, TOKEN, SHARED (deduplicated)
 
 	// Parse back to verify
 	parsed, err := parseBuildEnv(string(result))
@@ -111,20 +112,23 @@ func TestMergeBuildEnvContent(t *testing.T) {
 }
 
 func TestMergeBuildEnvContentBothNil(t *testing.T) {
-	result := MergeBuildEnvContent(nil, nil)
+	result, count := MergeBuildEnvContent(nil, nil)
 	assert.Nil(t, result)
+	assert.Equal(t, 0, count)
 }
 
 func TestMergeBuildEnvContentOnlyToml(t *testing.T) {
 	tomlArgs := map[string]string{"FOO": "bar"}
-	result := MergeBuildEnvContent(tomlArgs, nil)
+	result, count := MergeBuildEnvContent(tomlArgs, nil)
 	assert.NotNil(t, result)
+	assert.Equal(t, 1, count)
 	assert.Contains(t, string(result), "FOO=bar")
 }
 
 func TestMergeBuildEnvContentOnlyEnv(t *testing.T) {
 	envArgs := map[string]string{"FOO": "bar"}
-	result := MergeBuildEnvContent(nil, envArgs)
+	result, count := MergeBuildEnvContent(nil, envArgs)
 	assert.NotNil(t, result)
+	assert.Equal(t, 1, count)
 	assert.Contains(t, string(result), "FOO=bar")
 }

--- a/cli/core/buildenv_test.go
+++ b/cli/core/buildenv_test.go
@@ -1,0 +1,130 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBuildEnvBasic(t *testing.T) {
+	args, err := parseBuildEnv("FOO=bar\nBAZ=qux\n")
+	require.NoError(t, err)
+	assert.Equal(t, "bar", args["FOO"])
+	assert.Equal(t, "qux", args["BAZ"])
+}
+
+func TestParseBuildEnvEmptyValue(t *testing.T) {
+	args, err := parseBuildEnv("KEY=\n")
+	require.NoError(t, err)
+	assert.Equal(t, "", args["KEY"])
+}
+
+func TestParseBuildEnvCommentsAndBlanks(t *testing.T) {
+	args, err := parseBuildEnv("# comment\n\nFOO=bar\n  # another comment\nBAZ=qux\n\n")
+	require.NoError(t, err)
+	assert.Len(t, args, 2)
+	assert.Equal(t, "bar", args["FOO"])
+	assert.Equal(t, "qux", args["BAZ"])
+}
+
+func TestParseBuildEnvValueWithEquals(t *testing.T) {
+	args, err := parseBuildEnv("TOKEN=abc=def==\n")
+	require.NoError(t, err)
+	assert.Equal(t, "abc=def==", args["TOKEN"])
+}
+
+func TestParseBuildEnvInvalidNoEquals(t *testing.T) {
+	_, err := parseBuildEnv("INVALID_LINE\n")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid format")
+}
+
+func TestParseBuildEnvEmptyKey(t *testing.T) {
+	_, err := parseBuildEnv("=value\n")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty key")
+}
+
+func TestParseBuildEnvEmpty(t *testing.T) {
+	args, err := parseBuildEnv("")
+	require.NoError(t, err)
+	assert.Nil(t, args)
+}
+
+func TestParseBuildEnvWhitespaceTrimming(t *testing.T) {
+	args, err := parseBuildEnv("  FOO = bar  \n  BAZ=  qux  \n")
+	require.NoError(t, err)
+	assert.Equal(t, "bar", args["FOO"])
+	assert.Equal(t, "qux", args["BAZ"])
+}
+
+func TestReadBuildEnvDefaultMissing(t *testing.T) {
+	dir := t.TempDir()
+	args, err := ReadBuildEnv(dir, "")
+	require.NoError(t, err)
+	assert.Nil(t, args)
+}
+
+func TestReadBuildEnvDefaultExists(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, ".build-env"), []byte("FOO=bar\n"), 0644)
+	require.NoError(t, err)
+
+	args, err := ReadBuildEnv(dir, "")
+	require.NoError(t, err)
+	assert.Equal(t, "bar", args["FOO"])
+}
+
+func TestReadBuildEnvCustomPathMissing(t *testing.T) {
+	dir := t.TempDir()
+	_, err := ReadBuildEnv(dir, ".build-env.production")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestReadBuildEnvCustomPathExists(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, ".build-env.production"), []byte("NODE_ENV=production\n"), 0644)
+	require.NoError(t, err)
+
+	args, err := ReadBuildEnv(dir, ".build-env.production")
+	require.NoError(t, err)
+	assert.Equal(t, "production", args["NODE_ENV"])
+}
+
+func TestMergeBuildEnvContent(t *testing.T) {
+	tomlArgs := map[string]string{"NODE_ENV": "production", "SHARED": "from-toml"}
+	envArgs := map[string]string{"TOKEN": "secret", "SHARED": "from-env"}
+
+	result := MergeBuildEnvContent(tomlArgs, envArgs)
+	assert.NotNil(t, result)
+
+	// Parse back to verify
+	parsed, err := parseBuildEnv(string(result))
+	require.NoError(t, err)
+	assert.Equal(t, "production", parsed["NODE_ENV"])
+	assert.Equal(t, "secret", parsed["TOKEN"])
+	assert.Equal(t, "from-env", parsed["SHARED"]) // .build-env wins
+}
+
+func TestMergeBuildEnvContentBothNil(t *testing.T) {
+	result := MergeBuildEnvContent(nil, nil)
+	assert.Nil(t, result)
+}
+
+func TestMergeBuildEnvContentOnlyToml(t *testing.T) {
+	tomlArgs := map[string]string{"FOO": "bar"}
+	result := MergeBuildEnvContent(tomlArgs, nil)
+	assert.NotNil(t, result)
+	assert.Contains(t, string(result), "FOO=bar")
+}
+
+func TestMergeBuildEnvContentOnlyEnv(t *testing.T) {
+	envArgs := map[string]string{"FOO": "bar"}
+	result := MergeBuildEnvContent(nil, envArgs)
+	assert.NotNil(t, result)
+	assert.Contains(t, string(result), "FOO=bar")
+}

--- a/cli/core/config.go
+++ b/cli/core/config.go
@@ -235,6 +235,11 @@ type Package struct {
 	Type string `toml:"type,omitempty"`
 }
 
+// BuildConfig represents the [build] section of blaxel.toml
+type BuildConfig struct {
+	Args map[string]string `toml:"args,omitempty"`
+}
+
 // readConfigToml reads the config.toml file and upgrade config according to content
 type Config struct {
 	Name         string                    `toml:"name"`
@@ -260,6 +265,7 @@ type Config struct {
 	Public       *bool                     `toml:"public,omitempty"`
 	GithubRunner *map[string]interface{}   `toml:"githubRunner,omitempty"`
 	Image        string                    `toml:"image,omitempty"`
+	Build        *BuildConfig              `toml:"build,omitempty"`
 }
 
 // blaxelTomlWarning stores any warning from parsing blaxel.toml
@@ -420,6 +426,12 @@ memory = 4096
 # Pre-built Docker image (optional)
 # When set, the build step is skipped and this image is used directly
 # image = "docker.io/myorg/myimage:latest"
+
+# Build arguments (optional) - passed as Docker --build-arg
+# For secrets, prefer a .build-env file (added to .gitignore)
+# [build.args]
+# NODE_ENV = "production"
+# ENABLE_TELEMETRY = "true"
 
 # Volumes for Sandbox (optional)
 # [[volumes]]

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -47,6 +47,7 @@ func DeployCmd() *cobra.Command {
 	var registryCreds []string
 	var dockerConfigPath string
 	var timeoutStr string
+	var buildEnvPath string
 
 	cmd := &cobra.Command{
 		Use:     "deploy",
@@ -102,6 +103,9 @@ all projects in a monorepo (looks for blaxel.toml in subdirectories).`,
 
   # Deploy specifying a resource type
   bl deploy --type sandbox
+
+  # Deploy with Docker build args from a .build-env file
+  bl deploy --build-env .build-env.production
 
   # Recursively deploy all projects in monorepo
   bl deploy -R`,
@@ -165,6 +169,21 @@ all projects in a monorepo (looks for blaxel.toml in subdirectories).`,
 				core.ExitWithError(dockerErr)
 			}
 
+			// Resolve build-env args
+			envArgs, buildEnvErr := core.ReadBuildEnv(projectDir, buildEnvPath)
+			if buildEnvErr != nil {
+				core.PrintError("Deploy", fmt.Errorf("failed to read build-env file: %w", buildEnvErr))
+				core.ExitWithError(buildEnvErr)
+			}
+			var tomlBuildArgs map[string]string
+			if cfg := core.GetConfig(); cfg.Build != nil {
+				tomlBuildArgs = cfg.Build.Args
+			}
+			buildEnvContent := core.MergeBuildEnvContent(tomlBuildArgs, envArgs)
+			if buildEnvContent != nil {
+				fmt.Printf("Build args: %d variable(s) detected\n", len(envArgs)+len(tomlBuildArgs))
+			}
+
 			// Parse timeout
 			deployTimeout := mon.DefaultBuildTimeout
 			if timeoutStr != "" {
@@ -187,6 +206,7 @@ all projects in a monorepo (looks for blaxel.toml in subdirectories).`,
 				cwd:              cwd,
 				experimental:     experimental,
 				dockerConfigJSON: dockerConfigJSON,
+				buildEnvContent:  buildEnvContent,
 				timeout:          deployTimeout,
 				timeoutExplicit:  timeoutStr != "",
 			}
@@ -302,6 +322,7 @@ all projects in a monorepo (looks for blaxel.toml in subdirectories).`,
 	cmd.Flags().StringArrayVarP(&registryCreds, "registry-cred", "c", []string{}, "Registry credentials (format: registry=username:password, repeatable)")
 	cmd.Flags().StringVar(&dockerConfigPath, "docker-config", "", "Path to a Docker config.json file with registry credentials")
 	cmd.Flags().StringVar(&timeoutStr, "timeout", "", "Timeout for build and deployment monitoring (e.g. 30m, 1h). Defaults to 15m")
+	cmd.Flags().StringVar(&buildEnvPath, "build-env", "", "Path to a build-env file with Docker build args (default: auto-detect .build-env)")
 	return cmd
 }
 
@@ -318,6 +339,7 @@ type Deployment struct {
 	metadataURL            string
 	experimental           bool
 	dockerConfigJSON       []byte
+	buildEnvContent        []byte
 	timeout                time.Duration
 	timeoutExplicit        bool
 }
@@ -1754,6 +1776,7 @@ func (d *Deployment) IgnoredPaths() []string {
 	if err != nil {
 		return []string{
 			".blaxel",
+			".build-env",
 			".docker",
 			".git",
 			"dist",
@@ -1984,6 +2007,13 @@ func (d *Deployment) createArchive(_ string, writer archiveWriter) error {
 	if d.dockerConfigJSON != nil {
 		if err := writer.addBytes(d.dockerConfigJSON, ".docker/config.json"); err != nil {
 			return fmt.Errorf("failed to add docker config to archive: %w", err)
+		}
+	}
+
+	// Inject build-env file if available
+	if d.buildEnvContent != nil {
+		if err := writer.addBytes(d.buildEnvContent, ".build-env"); err != nil {
+			return fmt.Errorf("failed to add build-env to archive: %w", err)
 		}
 	}
 

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -179,9 +179,9 @@ all projects in a monorepo (looks for blaxel.toml in subdirectories).`,
 			if cfg := core.GetConfig(); cfg.Build != nil {
 				tomlBuildArgs = cfg.Build.Args
 			}
-			buildEnvContent := core.MergeBuildEnvContent(tomlBuildArgs, envArgs)
+			buildEnvContent, buildArgCount := core.MergeBuildEnvContent(tomlBuildArgs, envArgs)
 			if buildEnvContent != nil {
-				fmt.Printf("Build args: %d variable(s) detected\n", len(envArgs)+len(tomlBuildArgs))
+				fmt.Printf("Build args: %d variable(s) detected\n", buildArgCount)
 			}
 
 			// Parse timeout
@@ -1791,7 +1791,8 @@ func (d *Deployment) IgnoredPaths() []string {
 
 	// Parse the .blaxelignore file, filtering out comments and empty lines
 	lines := strings.Split(string(content), "\n")
-	var ignoredPaths []string
+	// Always exclude .build-env regardless of .blaxelignore content
+	ignoredPaths := []string{".build-env"}
 	for _, line := range lines {
 		// Trim whitespace
 		line = strings.TrimSpace(line)

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -2011,8 +2011,8 @@ func (d *Deployment) createArchive(_ string, writer archiveWriter) error {
 		}
 	}
 
-	// Inject build-env file if available
-	if d.buildEnvContent != nil {
+	// Inject build-env file if available (skip for volume-templates, which don't use Docker builds)
+	if d.buildEnvContent != nil && !core.IsVolumeTemplate(config.Type) {
 		if err := writer.addBytes(d.buildEnvContent, ".build-env"); err != nil {
 			return fmt.Errorf("failed to add build-env to archive: %w", err)
 		}

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -104,8 +104,8 @@ all projects in a monorepo (looks for blaxel.toml in subdirectories).`,
   # Deploy specifying a resource type
   bl deploy --type sandbox
 
-  # Deploy with Docker build args from a .build-env file
-  bl deploy --build-env .build-env.production
+  # Deploy with Docker build args from a .env.build file
+  bl deploy --build-env-file .env.build.production
 
   # Recursively deploy all projects in monorepo
   bl deploy -R`,
@@ -172,7 +172,7 @@ all projects in a monorepo (looks for blaxel.toml in subdirectories).`,
 			// Resolve build-env args
 			envArgs, buildEnvErr := core.ReadBuildEnv(projectDir, buildEnvPath)
 			if buildEnvErr != nil {
-				core.PrintError("Deploy", fmt.Errorf("failed to read build-env file: %w", buildEnvErr))
+				core.PrintError("Deploy", fmt.Errorf("failed to read .env.build file: %w", buildEnvErr))
 				core.ExitWithError(buildEnvErr)
 			}
 			var tomlBuildArgs map[string]string
@@ -322,7 +322,7 @@ all projects in a monorepo (looks for blaxel.toml in subdirectories).`,
 	cmd.Flags().StringArrayVarP(&registryCreds, "registry-cred", "c", []string{}, "Registry credentials (format: registry=username:password, repeatable)")
 	cmd.Flags().StringVar(&dockerConfigPath, "docker-config", "", "Path to a Docker config.json file with registry credentials")
 	cmd.Flags().StringVar(&timeoutStr, "timeout", "", "Timeout for build and deployment monitoring (e.g. 30m, 1h). Defaults to 15m")
-	cmd.Flags().StringVar(&buildEnvPath, "build-env", "", "Path to a build-env file with Docker build args (default: auto-detect .build-env)")
+	cmd.Flags().StringVar(&buildEnvPath, "build-env-file", "", "Path to a build env file with Docker build args (default: auto-detect .env.build)")
 	return cmd
 }
 
@@ -1776,7 +1776,7 @@ func (d *Deployment) IgnoredPaths() []string {
 	if err != nil {
 		return []string{
 			".blaxel",
-			".build-env",
+			".env.build",
 			".docker",
 			".git",
 			"dist",
@@ -1791,8 +1791,8 @@ func (d *Deployment) IgnoredPaths() []string {
 
 	// Parse the .blaxelignore file, filtering out comments and empty lines
 	lines := strings.Split(string(content), "\n")
-	// Always exclude .build-env regardless of .blaxelignore content
-	ignoredPaths := []string{".build-env"}
+	// Always exclude .env.build regardless of .blaxelignore content
+	ignoredPaths := []string{".env.build"}
 	for _, line := range lines {
 		// Trim whitespace
 		line = strings.TrimSpace(line)
@@ -2011,10 +2011,10 @@ func (d *Deployment) createArchive(_ string, writer archiveWriter) error {
 		}
 	}
 
-	// Inject build-env file if available (skip for volume-templates, which don't use Docker builds)
+	// Inject .env.build file if available (skip for volume-templates, which don't use Docker builds)
 	if d.buildEnvContent != nil && !core.IsVolumeTemplate(config.Type) {
-		if err := writer.addBytes(d.buildEnvContent, ".build-env"); err != nil {
-			return fmt.Errorf("failed to add build-env to archive: %w", err)
+		if err := writer.addBytes(d.buildEnvContent, ".env.build"); err != nil {
+			return fmt.Errorf("failed to add .env.build to archive: %w", err)
 		}
 	}
 

--- a/cli/push.go
+++ b/cli/push.go
@@ -243,9 +243,9 @@ You must run this command from a directory containing a blaxel.toml file.`,
 				if cfg := core.GetConfig(); cfg.Build != nil {
 					tomlBuildArgs = cfg.Build.Args
 				}
-				buildEnvContent := core.MergeBuildEnvContent(tomlBuildArgs, envArgs)
+				buildEnvContent, buildArgCount := core.MergeBuildEnvContent(tomlBuildArgs, envArgs)
 				if buildEnvContent != nil {
-					fmt.Printf("Build args: %d variable(s) detected\n", len(envArgs)+len(tomlBuildArgs))
+					fmt.Printf("Build args: %d variable(s) detected\n", buildArgCount)
 				}
 
 				deployment := Deployment{

--- a/cli/push.go
+++ b/cli/push.go
@@ -236,7 +236,7 @@ You must run this command from a directory containing a blaxel.toml file.`,
 				// Resolve build-env args
 				envArgs, buildEnvErr := core.ReadBuildEnv(projectDir, buildEnvPath)
 				if buildEnvErr != nil {
-					core.PrintError("Push", fmt.Errorf("failed to read build-env file: %w", buildEnvErr))
+					core.PrintError("Push", fmt.Errorf("failed to read .env.build file: %w", buildEnvErr))
 					core.ExitWithError(buildEnvErr)
 				}
 				var tomlBuildArgs map[string]string
@@ -337,7 +337,7 @@ You must run this command from a directory containing a blaxel.toml file.`,
 	cmd.Flags().StringArrayVarP(&registryCreds, "registry-cred", "c", []string{}, "Registry credentials (format: registry=username:password, repeatable)")
 	cmd.Flags().StringVar(&dockerConfigPath, "docker-config", "", "Path to a Docker config.json file with registry credentials")
 	cmd.Flags().StringVar(&timeoutStr, "timeout", "", "Timeout for build log monitoring (e.g. 30m, 1h). Defaults to 15m")
-	cmd.Flags().StringVar(&buildEnvPath, "build-env", "", "Path to a build-env file with Docker build args (default: auto-detect .build-env)")
+	cmd.Flags().StringVar(&buildEnvPath, "build-env-file", "", "Path to a build env file with Docker build args (default: auto-detect .env.build)")
 
 	return cmd
 }

--- a/cli/push.go
+++ b/cli/push.go
@@ -53,6 +53,7 @@ func PushCmd() *cobra.Command {
 	var registryCreds []string
 	var dockerConfigPath string
 	var timeoutStr string
+	var buildEnvPath string
 
 	cmd := &cobra.Command{
 		Use:   "push",
@@ -232,11 +233,27 @@ You must run this command from a directory containing a blaxel.toml file.`,
 					core.ExitWithError(dockerErr)
 				}
 
+				// Resolve build-env args
+				envArgs, buildEnvErr := core.ReadBuildEnv(projectDir, buildEnvPath)
+				if buildEnvErr != nil {
+					core.PrintError("Push", fmt.Errorf("failed to read build-env file: %w", buildEnvErr))
+					core.ExitWithError(buildEnvErr)
+				}
+				var tomlBuildArgs map[string]string
+				if cfg := core.GetConfig(); cfg.Build != nil {
+					tomlBuildArgs = cfg.Build.Args
+				}
+				buildEnvContent := core.MergeBuildEnvContent(tomlBuildArgs, envArgs)
+				if buildEnvContent != nil {
+					fmt.Printf("Build args: %d variable(s) detected\n", len(envArgs)+len(tomlBuildArgs))
+				}
+
 				deployment := Deployment{
 					folder:           folder,
 					name:             name,
 					cwd:              cwd,
 					dockerConfigJSON: dockerConfigJSON,
+					buildEnvContent:  buildEnvContent,
 				}
 
 				fmt.Printf("Packaging source code for %s...\n", imageRef(resourceType, name))
@@ -320,6 +337,7 @@ You must run this command from a directory containing a blaxel.toml file.`,
 	cmd.Flags().StringArrayVarP(&registryCreds, "registry-cred", "c", []string{}, "Registry credentials (format: registry=username:password, repeatable)")
 	cmd.Flags().StringVar(&dockerConfigPath, "docker-config", "", "Path to a Docker config.json file with registry credentials")
 	cmd.Flags().StringVar(&timeoutStr, "timeout", "", "Timeout for build log monitoring (e.g. 30m, 1h). Defaults to 15m")
+	cmd.Flags().StringVar(&buildEnvPath, "build-env", "", "Path to a build-env file with Docker build args (default: auto-detect .build-env)")
 
 	return cmd
 }


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/toolkit/pull/290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds Docker build args support via a `.env.build` file and `[build.args]` in `blaxel.toml`. The feature parses, merges, and injects build args into the deployment archive, with the `.env.build` file excluded from the normal archive walk to prevent double-inclusion. Both `deploy` and `push` commands get a `--build-env-file` flag.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit c0c1eba158b4eda2467e8a1dd4ceaaa6e3519fdc.</sup>
<!-- /MENDRAL_SUMMARY -->