### PR TITLE
Add guidance on process exec failure

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -140,6 +140,9 @@ This is useful for testing specific endpoints or non-standard API calls.`,
   # Execute a command with a working directory and a process name
   bl run sandbox my-sandbox --path /process --data '{"command": "npm install", "name": "install-deps", "workingDir": "/app"}'
 
+  # For complex commands (nested quotes, backslashes, multiline), save the JSON in a file with your editor then pass it via --file (no shell-escaping)
+  bl run sandbox my-sandbox --path /process --file ./process-payload.json
+
   # Execute a long-running command with keep-alive (prevents sandbox auto-standby)
   bl run sandbox my-sandbox --path /process --data '{"command": "npm run dev -- --port 3000", "name": "dev-server", "keepAlive": true}'
 
@@ -158,6 +161,7 @@ This is useful for testing specific endpoints or non-standard API calls.`,
 			resourceName := args[1]
 			headers := make(map[string]string)
 			outputFormat := core.GetOutputFormat()
+			dataFromInlineFlag := data != ""
 
 			// Parse header flags into map
 			for _, header := range headerFlags {
@@ -195,6 +199,7 @@ This is useful for testing specific endpoints or non-standard API calls.`,
 				} else {
 					data = string(fileContent)
 				}
+				dataFromInlineFlag = false
 			}
 
 			// Handle file upload if specified
@@ -206,6 +211,7 @@ This is useful for testing specific endpoints or non-standard API calls.`,
 					core.ExitWithError(err)
 				}
 				data = string(fileContent)
+				dataFromInlineFlag = false
 			}
 			if (resourceType == "model" || resourceType == "models") && path == "" {
 				path = getModelDefaultPath(resourceName)
@@ -223,6 +229,20 @@ This is useful for testing specific endpoints or non-standard API calls.`,
 				path = "/executions"
 			}
 
+			if resourceType == "mcp" {
+				resourceType = "functions"
+			}
+			if resourceType == "sbx" {
+				resourceType = "sandbox"
+			}
+
+			if dataFromInlineFlag {
+				if err := validateInlineRunDataJSON(data, resourceType, path); err != nil {
+					core.PrintError("Run", err)
+					core.ExitWithError(err)
+				}
+			}
+
 			// Print descriptive info for job execution (skip if raw output format)
 			if isJob && !isRawOutput {
 				core.PrintInfo(fmt.Sprintf("Starting job execution for '%s'...", resourceName))
@@ -231,12 +251,6 @@ This is useful for testing specific endpoints or non-standard API calls.`,
 				if err := json.Unmarshal([]byte(data), &batch); err == nil && len(batch.Tasks) > 0 {
 					core.PrintInfo(fmt.Sprintf("Batch contains %d task(s)", len(batch.Tasks)))
 				}
-			}
-			if resourceType == "mcp" {
-				resourceType = "functions"
-			}
-			if resourceType == "sbx" {
-				resourceType = "sandbox"
 			}
 
 			// Add streaming headers when --stream flag is set
@@ -411,6 +425,32 @@ This is useful for testing specific endpoints or non-standard API calls.`,
 	cmd.Flags().BoolVar(&stream, "stream", false, "Stream SSE responses in real-time")
 	cmd.Flags().IntVar(&timeout, "timeout", 0, "Request timeout in seconds (default: no timeout)")
 	return cmd
+}
+
+func isSandboxResource(resourceType string) bool {
+	return resourceType == "sandbox" || resourceType == "sandboxes"
+}
+
+func normalizeRequestPath(path string) string {
+	if path == "" || strings.HasPrefix(path, "/") {
+		return path
+	}
+	return "/" + path
+}
+
+func validateInlineRunDataJSON(data, resourceType, path string) error {
+	if !isSandboxResource(resourceType) || normalizeRequestPath(path) != "/process" {
+		return nil
+	}
+
+	var raw json.RawMessage
+	if err := json.Unmarshal([]byte(data), &raw); err != nil {
+		return fmt.Errorf(
+			"invalid JSON passed to --data: %v. For sandbox /process payloads with nested quotes, backslashes, or newlines, write the JSON to a file and pass it via --file <path> to avoid shell-escaping collisions",
+			err,
+		)
+	}
+	return nil
 }
 
 // runRequest executes a request to a blaxel resource using the SDK client

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -152,6 +152,27 @@ func TestRunCmdExamples(t *testing.T) {
 	assert.NotEmpty(t, cmd.Example)
 	assert.Contains(t, cmd.Example, "bl run agent")
 	assert.Contains(t, cmd.Example, "bl run job")
+	assert.Contains(t, cmd.Example, "--path /process --file")
+}
+
+func TestValidateInlineRunDataJSONReturnsSandboxProcessHint(t *testing.T) {
+	err := validateInlineRunDataJSON(`{"command":"bad \' escape"}`, "sandbox", "process")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid JSON passed to --data")
+	assert.Contains(t, err.Error(), "sandbox /process")
+	assert.Contains(t, err.Error(), "--file")
+}
+
+func TestValidateInlineRunDataJSONIgnoresOtherRunData(t *testing.T) {
+	require.NoError(t, validateInlineRunDataJSON(`not json`, "agent", "/invoke"))
+	require.NoError(t, validateInlineRunDataJSON(`not json`, "sandbox", "/filesystem//tmp"))
+}
+
+func TestValidateInlineRunDataJSONAcceptsValidProcessPayload(t *testing.T) {
+	payload := `{"command":"sh -lc 'python3 -c \"print(\\\"hello\\\")\"'","waitForCompletion":true}`
+
+	require.NoError(t, validateInlineRunDataJSON(payload, "sandbox", "/process"))
 }
 
 func TestBatchStructNestedTasks(t *testing.T) {

--- a/docs/bl_deploy.md
+++ b/docs/bl_deploy.md
@@ -66,6 +66,9 @@ bl deploy [flags]
   # Deploy specifying a resource type
   bl deploy --type sandbox
 
+  # Deploy with Docker build args from a .env.build file
+  bl deploy --build-env-file .env.build.production
+
   # Recursively deploy all projects in monorepo
   bl deploy -R
 ```
@@ -73,6 +76,7 @@ bl deploy [flags]
 ### Options
 
 ```
+      --build-env-file string       Path to a build env file with Docker build args (default: auto-detect .env.build)
   -d, --directory string            Deployment app path, can be a sub directory
       --docker-config string        Path to a Docker config.json file with registry credentials
       --dryrun                      Dry run the deployment

--- a/docs/bl_push.md
+++ b/docs/bl_push.md
@@ -49,6 +49,7 @@ bl push [flags]
 ### Options
 
 ```
+      --build-env-file string       Path to a build env file with Docker build args (default: auto-detect .env.build)
   -d, --directory string            Source directory path
       --docker-config string        Path to a Docker config.json file with registry credentials
   -h, --help                        help for push

--- a/docs/bl_run.md
+++ b/docs/bl_run.md
@@ -102,6 +102,9 @@ bl run resource-type resource-name [flags]
   # Execute a command with a working directory and a process name
   bl run sandbox my-sandbox --path /process --data '{"command": "npm install", "name": "install-deps", "workingDir": "/app"}'
 
+  # For complex commands (nested quotes, backslashes, multiline), save the JSON in a file with your editor then pass it via --file (no shell-escaping)
+  bl run sandbox my-sandbox --path /process --file ./process-payload.json
+
   # Execute a long-running command with keep-alive (prevents sandbox auto-standby)
   bl run sandbox my-sandbox --path /process --data '{"command": "npm run dev -- --port 3000", "name": "dev-server", "keepAlive": true}'
 


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/toolkit/pull/291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds user-facing guidance when inline `--data` JSON fails to parse for sandbox `/process` endpoints. Introduces `validateInlineRunDataJSON` that runs only on inline data (not `--file`), moves resource-type normalization (`sbx`→`sandbox`, `mcp`→`functions`) earlier so it precedes validation, and adds a `--file` example to the CLI help text and docs.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 7973cd766c17a1d89c856c41cda0c2353a66623b.</sup>
<!-- /MENDRAL_SUMMARY -->