### PR TITLE
fix: improve CLI agent output contracts (PM-1729, PM-2129)

### DIFF
--- a/cli/core/create.go
+++ b/cli/core/create.go
@@ -51,6 +51,44 @@ type CreateFlowConfig struct {
 	BlaxelTomlResourceType string
 }
 
+type createFlowDeps struct {
+	RetrieveTemplates func(templateType string, noTTY bool, errorPrefix string) (Templates, error)
+	CloneTemplate     func(opts TemplateOptions, templates Templates, noTTY bool, errorPrefix string, spinnerTitle string) error
+	CleanTemplate     func(directory string)
+	EditBlaxelToml    func(resourceType string, projectName string, directory string) error
+	OutputFormat      func() string
+}
+
+func defaultCreateFlowDeps() createFlowDeps {
+	return createFlowDeps{
+		RetrieveTemplates: RetrieveTemplatesWithSpinner,
+		CloneTemplate:     CloneTemplateWithSpinner,
+		CleanTemplate:     CleanTemplate,
+		EditBlaxelToml:    EditBlaxelTomlInCurrentDir,
+		OutputFormat:      GetOutputFormat,
+	}
+}
+
+func fillCreateFlowDeps(deps createFlowDeps) createFlowDeps {
+	defaults := defaultCreateFlowDeps()
+	if deps.RetrieveTemplates == nil {
+		deps.RetrieveTemplates = defaults.RetrieveTemplates
+	}
+	if deps.CloneTemplate == nil {
+		deps.CloneTemplate = defaults.CloneTemplate
+	}
+	if deps.CleanTemplate == nil {
+		deps.CleanTemplate = defaults.CleanTemplate
+	}
+	if deps.EditBlaxelToml == nil {
+		deps.EditBlaxelToml = defaults.EditBlaxelToml
+	}
+	if deps.OutputFormat == nil {
+		deps.OutputFormat = defaults.OutputFormat
+	}
+	return deps
+}
+
 // runCreateFlow centralizes the common steps for all create-* commands while
 // preserving each command's specific behavior via the config and callbacks.
 //
@@ -66,6 +104,21 @@ func runCreateFlow(
 	promptFunc func(directory string, templates Templates) TemplateOptions,
 	successFunc func(opts TemplateOptions),
 ) {
+	if err := runCreateFlowWithDeps(dirArg, templateNameFlag, cfg, promptFunc, successFunc, defaultCreateFlowDeps()); err != nil {
+		ExitWithError(err)
+	}
+}
+
+func runCreateFlowWithDeps(
+	dirArg string,
+	templateNameFlag string,
+	cfg CreateFlowConfig,
+	promptFunc func(directory string, templates Templates) TemplateOptions,
+	successFunc func(opts TemplateOptions),
+	deps createFlowDeps,
+) error {
+	deps = fillCreateFlowDeps(deps)
+
 	// Accept shorthand template names without the "template-" prefix
 	if templateNameFlag != "" && !strings.HasPrefix(templateNameFlag, "template-") {
 		templateNameFlag = "template-" + templateNameFlag
@@ -77,15 +130,16 @@ func runCreateFlow(
 	// If directory arg provided, ensure it doesn't already exist
 	if dirArg != "" {
 		if _, err := os.Stat(dirArg); !os.IsNotExist(err) {
-			PrintError(cfg.ErrorPrefix, fmt.Errorf("directory '%s' already exists", dirArg))
-			return
+			createErr := fmt.Errorf("directory '%s' already exists", dirArg)
+			PrintError(cfg.ErrorPrefix, createErr)
+			return createErr
 		}
 	}
 
 	// Retrieve templates (with or without spinner)
-	templates, err := RetrieveTemplatesWithSpinner(cfg.TemplateType, cfg.NoTTY, cfg.ErrorPrefix)
+	templates, err := deps.RetrieveTemplates(cfg.TemplateType, cfg.NoTTY, cfg.ErrorPrefix)
 	if err != nil {
-		ExitWithError(err)
+		return err
 	}
 
 	// Resolve options
@@ -98,13 +152,15 @@ func runCreateFlow(
 			selectedDir = templateNameFlag
 		}
 		if _, err := os.Stat(selectedDir); !os.IsNotExist(err) {
-			PrintError(cfg.ErrorPrefix, fmt.Errorf("directory '%s' already exists", selectedDir))
-			return
+			createErr := fmt.Errorf("directory '%s' already exists", selectedDir)
+			PrintError(cfg.ErrorPrefix, createErr)
+			return createErr
 		}
 		opts = CreateDefaultTemplateOptions(selectedDir, templateNameFlag, templates)
 		if opts.TemplateName == "" {
-			PrintError(cfg.ErrorPrefix, fmt.Errorf("template '%s' not found", templateNameFlag))
-			fmt.Println("Available templates:")
+			createErr := fmt.Errorf("template '%s' not found", templateNameFlag)
+			PrintError(cfg.ErrorPrefix, createErr)
+			PrintDiagnostic("Available templates:")
 			langs := templates.GetLanguages()
 			for _, lang := range langs {
 				hasTemplates := false
@@ -113,24 +169,25 @@ func runCreateFlow(
 						continue
 					}
 					if !hasTemplates {
-						fmt.Printf("- %s:\n", lang)
+						PrintDiagnostic(fmt.Sprintf("- %s:", lang))
 						hasTemplates = true
 					}
 					name := strings.TrimPrefix(templateDisplayName(t), "template-")
 					if t.Description != "" {
-						fmt.Printf("  - %-30s %s\n", name, t.Description)
+						PrintDiagnostic(fmt.Sprintf("  - %-30s %s", name, t.Description))
 					} else {
-						fmt.Printf("  - %s\n", name)
+						PrintDiagnostic(fmt.Sprintf("  - %s", name))
 					}
 				}
 			}
-			return
+			return createErr
 		}
 	case cfg.NoTTY && cfg.TemplateType == "mcp":
 		// Special-case retained behavior: for MCP with --yes but no template we require directory and pick default
 		if dirArg == "" {
-			PrintError(cfg.ErrorPrefix, fmt.Errorf("directory name is required"))
-			return
+			createErr := fmt.Errorf("directory name is required")
+			PrintError(cfg.ErrorPrefix, createErr)
+			return createErr
 		}
 		opts = CreateDefaultTemplateOptions(dirArg, "", templates)
 	default:
@@ -138,29 +195,34 @@ func runCreateFlow(
 		opts = promptFunc(dirArg, templates)
 		// Safety checks
 		if opts.Directory == "" {
-			PrintError(cfg.ErrorPrefix, fmt.Errorf("directory name is required"))
-			return
+			createErr := fmt.Errorf("directory name is required")
+			PrintError(cfg.ErrorPrefix, createErr)
+			return createErr
 		}
 		if _, err := os.Stat(opts.Directory); !os.IsNotExist(err) {
-			PrintError(cfg.ErrorPrefix, fmt.Errorf("directory '%s' already exists", opts.Directory))
-			return
+			createErr := fmt.Errorf("directory '%s' already exists", opts.Directory)
+			PrintError(cfg.ErrorPrefix, createErr)
+			return createErr
 		}
 	}
 
 	// Clone template using the unified helper
-	if err := CloneTemplateWithSpinner(opts, templates, cfg.NoTTY, cfg.ErrorPrefix, cfg.SpinnerTitle); err != nil {
-		return
+	if err := deps.CloneTemplate(opts, templates, cfg.NoTTY, cfg.ErrorPrefix, cfg.SpinnerTitle); err != nil {
+		return err
 	}
 
-	CleanTemplate(opts.Directory)
+	deps.CleanTemplate(opts.Directory)
 
 	// Optionally update blaxel.toml (only for those commands that did previously)
 	if cfg.BlaxelTomlResourceType != "" {
-		_ = EditBlaxelTomlInCurrentDir(cfg.BlaxelTomlResourceType, opts.ProjectName, opts.Directory)
+		if err := deps.EditBlaxelToml(cfg.BlaxelTomlResourceType, opts.ProjectName, opts.Directory); err != nil {
+			PrintError(cfg.ErrorPrefix, err)
+			return err
+		}
 	}
 
 	// If structured output is requested, print JSON/YAML and skip the regular success message
-	outputFmt := GetOutputFormat()
+	outputFmt := deps.OutputFormat()
 	if outputFmt == "json" || outputFmt == "yaml" {
 		result := map[string]string{
 			"directory": opts.Directory,
@@ -176,11 +238,12 @@ func runCreateFlow(
 			data, _ := yaml.Marshal(result)
 			fmt.Print(string(data))
 		}
-		return
+		return nil
 	}
 
 	// Let the caller print specific success instructions
 	successFunc(opts)
+	return nil
 }
 
 func templateDisplayName(t Template) string {

--- a/cli/core/create_test.go
+++ b/cli/core/create_test.go
@@ -1,11 +1,14 @@
 package core
 
 import (
+	"errors"
+	"path/filepath"
 	"regexp"
 	"testing"
 
 	blaxel "github.com/blaxel-ai/sdk-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateRandomDirectoryName(t *testing.T) {
@@ -137,4 +140,115 @@ func TestTemplateDisplayNameRegex(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestRunCreateFlowWithDepsReturnsErrorWhenDirectoryExists(t *testing.T) {
+	existingDir := t.TempDir()
+
+	err := runCreateFlowWithDeps(
+		existingDir,
+		"google-adk-py",
+		CreateFlowConfig{
+			TemplateType: "agent",
+			NoTTY:        true,
+			ErrorPrefix:  "Agent creation",
+			SpinnerTitle: "Creating your blaxel agent app...",
+		},
+		func(directory string, templates Templates) TemplateOptions {
+			t.Fatal("prompt should not run for an existing directory")
+			return TemplateOptions{}
+		},
+		func(opts TemplateOptions) {
+			t.Fatal("success should not run after an existing directory error")
+		},
+		createFlowDeps{},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+}
+
+func TestRunCreateFlowWithDepsReturnsErrorWhenTemplateNotFound(t *testing.T) {
+	var err error
+	stdout, stderr := captureStandardStreams(t, func() {
+		err = runCreateFlowWithDeps(
+			filepath.Join(t.TempDir(), "new-agent"),
+			"missing-template",
+			CreateFlowConfig{
+				TemplateType: "agent",
+				NoTTY:        true,
+				ErrorPrefix:  "Agent creation",
+				SpinnerTitle: "Creating your blaxel agent app...",
+			},
+			func(directory string, templates Templates) TemplateOptions {
+				t.Fatal("prompt should not run when a template flag is provided")
+				return TemplateOptions{}
+			},
+			func(opts TemplateOptions) {
+				t.Fatal("success should not run when template resolution fails")
+			},
+			createFlowDeps{
+				RetrieveTemplates: func(templateType string, noTTY bool, errorPrefix string) (Templates, error) {
+					return Templates{
+						{
+							Template: blaxel.Template{Name: "template-google-adk-py"},
+							Language: "python",
+							Type:     "agent",
+						},
+					}, nil
+				},
+			},
+		)
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "template 'template-missing-template' not found")
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "Available templates:")
+	assert.Contains(t, stderr, "google-adk-py")
+}
+
+func TestRunCreateFlowWithDepsReturnsCloneFailure(t *testing.T) {
+	cloneErr := errors.New("dependency install failed")
+	cleanCalled := false
+	successCalled := false
+
+	err := runCreateFlowWithDeps(
+		filepath.Join(t.TempDir(), "new-agent"),
+		"google-adk-py",
+		CreateFlowConfig{
+			TemplateType: "agent",
+			NoTTY:        true,
+			ErrorPrefix:  "Agent creation",
+			SpinnerTitle: "Creating your blaxel agent app...",
+		},
+		func(directory string, templates Templates) TemplateOptions {
+			t.Fatal("prompt should not run when a template flag is provided")
+			return TemplateOptions{}
+		},
+		func(opts TemplateOptions) {
+			successCalled = true
+		},
+		createFlowDeps{
+			RetrieveTemplates: func(templateType string, noTTY bool, errorPrefix string) (Templates, error) {
+				return Templates{
+					{
+						Template: blaxel.Template{Name: "template-google-adk-py"},
+						Language: "python",
+						Type:     "agent",
+					},
+				}, nil
+			},
+			CloneTemplate: func(opts TemplateOptions, templates Templates, noTTY bool, errorPrefix string, spinnerTitle string) error {
+				return cloneErr
+			},
+			CleanTemplate: func(directory string) {
+				cleanCalled = true
+			},
+		},
+	)
+
+	require.ErrorIs(t, err, cloneErr)
+	assert.False(t, cleanCalled)
+	assert.False(t, successCalled)
 }

--- a/cli/core/root.go
+++ b/cli/core/root.go
@@ -104,7 +104,7 @@ func writeVersionCache(cache versionCache) error {
 }
 
 func notifyNewVersionAvailable(latestVersion, currentVersion string) {
-	fmt.Printf("%s⚠️  A new version of Blaxel CLI is available: %s%s%s%s (current: %s%s%s)\n%sYou can update by running: %sbl upgrade%s\n%sOr follow the instructions at %s%s%s\n\n%s",
+	fmt.Fprintf(os.Stderr, "%s⚠️  A new version of Blaxel CLI is available: %s%s%s%s (current: %s%s%s)\n%sYou can update by running: %sbl upgrade%s\n%sOr follow the instructions at %s%s%s\n\n%s",
 		colorYellow, colorBold+colorGreen, latestVersion, colorReset, colorYellow, colorBold, currentVersion, colorReset+colorYellow,
 		colorYellow, colorBold+colorGreen, colorReset+colorYellow,
 		colorYellow, colorCyan, UPDATE_CLI_DOC_URL, colorReset+colorYellow, colorReset)

--- a/cli/core/root_test.go
+++ b/cli/core/root_test.go
@@ -169,6 +169,16 @@ func TestVersionCache(t *testing.T) {
 	})
 }
 
+func TestNotifyNewVersionAvailableWritesToStderr(t *testing.T) {
+	stdout, stderr := captureStandardStreams(t, func() {
+		notifyNewVersionAvailable("0.1.93", "0.1.92")
+	})
+
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "A new version of Blaxel CLI is available")
+	assert.Contains(t, stderr, "bl upgrade")
+}
+
 func TestGetConfig(t *testing.T) {
 	// Save original and restore
 	original := config

--- a/cli/core/utils.go
+++ b/cli/core/utils.go
@@ -362,19 +362,19 @@ func GetHuhTheme() *huh.Theme {
 // PrintError prints a formatted error message with colors
 func PrintError(operation string, err error) {
 	// Print error header with red color and bold
-	Print(fmt.Sprintf("%s %s\n",
+	PrintDiagnostic(fmt.Sprintf("%s %s\n",
 		color.New(color.FgRed, color.Bold).Sprint("✗"),
 		color.New(color.FgRed, color.Bold).Sprintf("%s failed", operation)))
 
 	// Print reason with lighter red color
-	Print(fmt.Sprintf("%s %s\n",
+	PrintDiagnostic(fmt.Sprintf("%s %s\n",
 		color.New(color.FgRed).Sprint("Reason:"),
 		color.New(color.FgWhite).Sprint(err.Error())))
 }
 
 // PrintWarning prints a formatted warning message with colors
 func PrintWarning(message string) {
-	Print(fmt.Sprintf("%s %s\n",
+	PrintDiagnostic(fmt.Sprintf("%s %s\n",
 		color.New(color.FgYellow, color.Bold).Sprint("⚠"),
 		color.New(color.FgYellow).Sprint(message)))
 }
@@ -398,6 +398,11 @@ func PrintInfoWithCommand(message string, command string) {
 		color.New(color.FgBlue, color.Bold).Sprint("ℹ"),
 		color.New(color.FgBlue).Sprint(message),
 		color.New(color.FgWhite, color.Bold).Sprint(command)))
+}
+
+func PrintDiagnostic(message string) {
+	message = strings.TrimSuffix(message, "\n")
+	fmt.Fprintln(os.Stderr, message)
 }
 
 func Print(message string) {

--- a/cli/core/utils_test.go
+++ b/cli/core/utils_test.go
@@ -1,6 +1,9 @@
 package core
 
 import (
+	"bytes"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,6 +11,68 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func captureStandardStreams(t *testing.T, fn func()) (string, string) {
+	t.Helper()
+
+	originalStdout := os.Stdout
+	originalStderr := os.Stderr
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	require.NoError(t, err)
+	stderrReader, stderrWriter, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stdout = stdoutWriter
+	os.Stderr = stderrWriter
+	t.Cleanup(func() {
+		os.Stdout = originalStdout
+		os.Stderr = originalStderr
+	})
+
+	fn()
+
+	os.Stdout = originalStdout
+	os.Stderr = originalStderr
+
+	require.NoError(t, stdoutWriter.Close())
+	require.NoError(t, stderrWriter.Close())
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	_, err = io.Copy(&stdout, stdoutReader)
+	require.NoError(t, err)
+	_, err = io.Copy(&stderr, stderrReader)
+	require.NoError(t, err)
+
+	return stdout.String(), stderr.String()
+}
+
+func TestPrintErrorWritesToStderr(t *testing.T) {
+	originalInteractive := interactiveMode
+	interactiveMode = false
+	t.Cleanup(func() { interactiveMode = originalInteractive })
+
+	stdout, stderr := captureStandardStreams(t, func() {
+		PrintError("Test operation", errors.New("bad input"))
+	})
+
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "Test operation failed")
+	assert.Contains(t, stderr, "bad input")
+}
+
+func TestPrintWarningWritesToStderr(t *testing.T) {
+	originalInteractive := interactiveMode
+	interactiveMode = false
+	t.Cleanup(func() { interactiveMode = originalInteractive })
+
+	stdout, stderr := captureStandardStreams(t, func() {
+		PrintWarning("careful now")
+	})
+
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "careful now")
+}
 
 func TestSlugify(t *testing.T) {
 	tests := []struct {

--- a/cli/createagentapp.go
+++ b/cli/createagentapp.go
@@ -21,7 +21,9 @@ func CreateAgentAppCmd() *cobra.Command {
 		Long:   "This command has been deprecated. Please use 'bl new agent' instead.",
 		Hidden: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			core.PrintError("create-agent-app", fmt.Errorf("this command has been deprecated. Please use 'bl new agent' instead"))
+			err := fmt.Errorf("this command has been deprecated. Please use 'bl new agent' instead")
+			core.PrintError("create-agent-app", err)
+			core.ExitWithError(err)
 		},
 	}
 	return cmd

--- a/cli/createjob.go
+++ b/cli/createjob.go
@@ -21,7 +21,9 @@ func CreateJobCmd() *cobra.Command {
 		Long:   "This command has been deprecated. Please use 'bl new job' instead.",
 		Hidden: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			core.PrintError("create-job", fmt.Errorf("this command has been deprecated. Please use 'bl new job' instead"))
+			err := fmt.Errorf("this command has been deprecated. Please use 'bl new job' instead")
+			core.PrintError("create-job", err)
+			core.ExitWithError(err)
 		},
 	}
 	return cmd

--- a/cli/createmcp.go
+++ b/cli/createmcp.go
@@ -21,7 +21,9 @@ func CreateMCPCmd() *cobra.Command {
 		Long:   "This command has been deprecated. Please use 'bl new mcp' instead.",
 		Hidden: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			core.PrintError("create-mcp", fmt.Errorf("this command has been deprecated. Please use 'bl new mcp' instead"))
+			err := fmt.Errorf("this command has been deprecated. Please use 'bl new mcp' instead")
+			core.PrintError("create-mcp", err)
+			core.ExitWithError(err)
 		},
 	}
 	return cmd

--- a/cli/createsandbox.go
+++ b/cli/createsandbox.go
@@ -22,7 +22,9 @@ func CreateSandboxCmd() *cobra.Command {
 		Long:    "This command has been deprecated. Please use 'bl new sandbox' instead.",
 		Hidden:  true,
 		Run: func(cmd *cobra.Command, args []string) {
-			core.PrintError("create-sandbox", fmt.Errorf("this command has been deprecated. Please use 'bl new sandbox' instead"))
+			err := fmt.Errorf("this command has been deprecated. Please use 'bl new sandbox' instead")
+			core.PrintError("create-sandbox", err)
+			core.ExitWithError(err)
 		},
 	}
 	return cmd

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -282,11 +282,20 @@ all projects in a monorepo (looks for blaxel.toml in subdirectories).`,
 			}
 
 			if dryRun {
-				err := deployment.Print(skipBuild)
-				if err != nil {
-					err = fmt.Errorf("error printing blaxel deployment: %w", err)
-					core.PrintError("Deploy", err)
-					core.ExitWithError(err)
+				if isStructured {
+					err := deployment.printDryRunStructuredOutput(outputFmt, skipBuild)
+					if err != nil {
+						err = fmt.Errorf("error printing structured dry run: %w", err)
+						core.PrintError("Deploy", err)
+						core.ExitWithError(err)
+					}
+				} else {
+					err := deployment.Print(skipBuild)
+					if err != nil {
+						err = fmt.Errorf("error printing blaxel deployment: %w", err)
+						core.PrintError("Deploy", err)
+						core.ExitWithError(err)
+					}
 				}
 				return
 			}
@@ -1631,6 +1640,115 @@ func (d *Deployment) printStructuredOutput(outputFmt string, startTime time.Time
 		data, _ := yaml.Marshal(result)
 		fmt.Print(string(data))
 	}
+}
+
+type dryRunFile struct {
+	Name string `json:"name" yaml:"name"`
+	Size int64  `json:"size" yaml:"size"`
+}
+
+type dryRunResult struct {
+	DryRun    bool          `json:"dryRun" yaml:"dryRun"`
+	Resources []core.Result `json:"resources" yaml:"resources"`
+	Files     []dryRunFile  `json:"files,omitempty" yaml:"files,omitempty"`
+}
+
+func (d *Deployment) printDryRunStructuredOutput(outputFmt string, skipBuild bool) error {
+	data, err := d.renderDryRunStructuredOutput(outputFmt, skipBuild)
+	if err != nil {
+		return err
+	}
+	switch outputFmt {
+	case "json":
+		fmt.Println(string(data))
+	case "yaml":
+		fmt.Print(string(data))
+	}
+	return nil
+}
+
+func (d *Deployment) renderDryRunStructuredOutput(outputFmt string, skipBuild bool) ([]byte, error) {
+	files, err := d.collectDryRunFiles(skipBuild)
+	if err != nil {
+		return nil, err
+	}
+	result := dryRunResult{
+		DryRun:    true,
+		Resources: d.blaxelDeployments,
+		Files:     files,
+	}
+	switch outputFmt {
+	case "json":
+		return json.MarshalIndent(result, "", "  ")
+	case "yaml":
+		return yaml.Marshal(result)
+	default:
+		return nil, fmt.Errorf("unsupported dry-run output format %q", outputFmt)
+	}
+}
+
+func (d *Deployment) collectDryRunFiles(skipBuild bool) ([]dryRunFile, error) {
+	config := core.GetConfig()
+	if skipBuild || config.Image != "" {
+		return nil, nil
+	}
+	if d.archive == nil {
+		return nil, nil
+	}
+	if core.IsVolumeTemplate(config.Type) {
+		return collectDryRunTarFiles(d.archive.Name())
+	}
+	return collectDryRunZipFiles(d.archive.Name())
+}
+
+func collectDryRunZipFiles(path string) ([]dryRunFile, error) {
+	zipFile, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reopen zip file: %w", err)
+	}
+	defer func() { _ = zipFile.Close() }()
+
+	fileInfo, err := zipFile.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get file info: %w", err)
+	}
+	zipReader, err := zip.NewReader(zipFile, fileInfo.Size())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create zip reader: %w", err)
+	}
+	files := make([]dryRunFile, 0, len(zipReader.File))
+	for _, file := range zipReader.File {
+		files = append(files, dryRunFile{
+			Name: file.Name,
+			Size: int64(file.FileInfo().Size()),
+		})
+	}
+	return files, nil
+}
+
+func collectDryRunTarFiles(path string) ([]dryRunFile, error) {
+	tarFile, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reopen tar file: %w", err)
+	}
+	defer func() { _ = tarFile.Close() }()
+
+	tarReader := tar.NewReader(tarFile)
+	var files []dryRunFile
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to read tar header: %w", err)
+		}
+		files = append(files, dryRunFile{
+			Name: header.Name,
+			Size: header.Size,
+		})
+	}
+	return files, nil
 }
 
 func (d *Deployment) Ready() {

--- a/cli/deploy_test.go
+++ b/cli/deploy_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"archive/tar"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,6 +51,49 @@ func TestDeployCmd(t *testing.T) {
 	yesFlag := cmd.Flags().Lookup("yes")
 	assert.NotNil(t, yesFlag)
 	assert.Equal(t, "y", yesFlag.Shorthand)
+}
+
+func TestDeploymentDryRunStructuredOutputJSON(t *testing.T) {
+	deployment := Deployment{
+		blaxelDeployments: []core.Result{
+			{
+				ApiVersion: "blaxel.ai/v1alpha1",
+				Kind:       "Sandbox",
+				Metadata: map[string]interface{}{
+					"name": "pm1729-dryrun",
+				},
+				Spec: map[string]interface{}{
+					"runtime": map[string]interface{}{
+						"image": "ubuntu:latest",
+					},
+				},
+			},
+		},
+	}
+
+	output, err := deployment.renderDryRunStructuredOutput("json", true)
+	require.NoError(t, err)
+
+	var payload struct {
+		DryRun    bool          `json:"dryRun"`
+		Resources []core.Result `json:"resources"`
+		Files     []dryRunFile  `json:"files"`
+	}
+	require.NoError(t, json.Unmarshal(output, &payload))
+	assert.True(t, payload.DryRun)
+	require.Len(t, payload.Resources, 1)
+	assert.Equal(t, "Sandbox", payload.Resources[0].Kind)
+	assert.Empty(t, payload.Files)
+}
+
+func TestDeploymentDryRunStructuredOutputRejectsUnknownFormat(t *testing.T) {
+	deployment := Deployment{}
+
+	output, err := deployment.renderDryRunStructuredOutput("table", true)
+
+	require.Error(t, err)
+	assert.Nil(t, output)
+	assert.Contains(t, err.Error(), "unsupported dry-run output format")
 }
 
 func TestDeploymentStruct(t *testing.T) {

--- a/cli/deprecated_test.go
+++ b/cli/deprecated_test.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeprecatedCreateCommandsExitNonZero(t *testing.T) {
+	commands := []string{
+		"create-agent-app",
+		"create-sandbox",
+		"create-job",
+		"create-mcp",
+	}
+
+	for _, commandName := range commands {
+		t.Run(commandName, func(t *testing.T) {
+			cmd := exec.Command(os.Args[0], "-test.run=TestDeprecatedCreateCommandsExitNonZeroHelper")
+			cmd.Env = append(os.Environ(), "BLAXEL_TEST_DEPRECATED_COMMAND="+commandName)
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+
+			err := cmd.Run()
+
+			require.Error(t, err)
+			var exitErr *exec.ExitError
+			require.ErrorAs(t, err, &exitErr)
+			assert.Equal(t, 1, exitErr.ExitCode())
+			assert.Empty(t, stdout.String())
+			assert.Contains(t, stderr.String(), "deprecated")
+		})
+	}
+}
+
+func TestDeprecatedCreateCommandsExitNonZeroHelper(t *testing.T) {
+	commandName := os.Getenv("BLAXEL_TEST_DEPRECATED_COMMAND")
+	if commandName == "" {
+		t.Skip("helper only runs in a subprocess")
+	}
+
+	var cmd *cobra.Command
+	switch commandName {
+	case "create-agent-app":
+		cmd = CreateAgentAppCmd()
+	case "create-sandbox":
+		cmd = CreateSandboxCmd()
+	case "create-job":
+		cmd = CreateJobCmd()
+	case "create-mcp":
+		cmd = CreateMCPCmd()
+	default:
+		t.Fatalf("unknown deprecated command %q", commandName)
+	}
+
+	cmd.SetArgs(nil)
+	require.NoError(t, cmd.Execute())
+}

--- a/cli/new.go
+++ b/cli/new.go
@@ -114,8 +114,9 @@ After Creation:
 
 			if t == "" {
 				if noTTY {
-					core.PrintError("New", fmt.Errorf("type is required when using --yes. Allowed: agent | mcp | sandbox | job | volumetemplate"))
-					return
+					err := fmt.Errorf("type is required when using --yes. Allowed: agent | mcp | sandbox | job | volumetemplate")
+					core.PrintError("New", err)
+					core.ExitWithError(err)
 				}
 				// Prompt for type using huh
 				var selected string
@@ -153,7 +154,9 @@ After Creation:
 			case newTypeVolumeTemplate:
 				core.RunVolumeTemplateCreation(dirArg, templateName, noTTY)
 			default:
-				core.PrintError("New", fmt.Errorf("unknown type '%s'. Allowed: agent | mcp | sandbox | job | volumetemplate", t))
+				err := fmt.Errorf("unknown type '%s'. Allowed: agent | mcp | sandbox | job | volumetemplate", t)
+				core.PrintError("New", err)
+				core.ExitWithError(err)
 			}
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	err := cli.Execute(version, commit, date)
 	if err != nil {
-		fmt.Println("Error", err)
+		fmt.Fprintln(os.Stderr, "Error", err)
 		core.ExitWithError(err)
 	}
 }


### PR DESCRIPTION
## Summary
- Make `bl new` non-interactive failure paths return nonzero instead of exiting successfully.
- Keep errors, warnings, unknown commands, and CLI update notices on stderr so stdout stays parseable.
- Add structured JSON/YAML output for `bl deploy --dryrun -y -o json|yaml` while preserving the existing human dry-run output.

## Why
PM-1729 showed that agent-driven CLI workflows need reliable exit codes and clean machine-readable stdout. This also addresses the highest-priority PM-2129 audit finding around stderr/stdout discipline.

Refs PM-1729, PM-2129.

## Verification
- `go test ./...`
- `git diff --check`
- Temp binary smoke checks: 7/7
  - existing directory error returns nonzero with empty stdout
  - invalid template error returns nonzero with empty stdout
  - missing `bl new -y` type returns nonzero with empty stdout
  - unknown command writes to stderr
  - `deploy --dryrun -y -o json` parses with `jq`
  - `deploy --dryrun -y -o yaml` emits structured dry-run fields
  - default human dry-run still emits manifest YAML

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Follow-up commit adds `core.ExitWithError` to the four deprecated `create-*` commands so they exit nonzero, and adds subprocess-based tests to verify the exit code and that stdout is empty on failure.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 07facfaea4df44a17ff946ef449355fed19b47f3.</sup>
<!-- /MENDRAL_SUMMARY -->