### PR TITLE
feat: add sandbox template choices

### DIFF
--- a/cli/core/config.go
+++ b/cli/core/config.go
@@ -433,10 +433,20 @@ memory = 4096
 # NODE_ENV = "production"
 # ENABLE_TELEMETRY = "true"
 
-# Volumes for Sandbox (optional)
+# Volumes for Sandbox (optional) - attach a pre-existing managed Volume
 # [[volumes]]
 # name = "my-volume"
 # mountPath = "/data"
+
+# Ephemeral volumes for Job (optional) - disk-backed scratch space.
+# Use mountPath = "/" to overlay the entire root filesystem with a writable
+# ephemeral disk (root overlay). For per-subpath ephemeral storage use any
+# other absolute path, e.g. "/home/runner".
+# [[volumes]]
+# name = "scratch"
+# type = "ephemeral"
+# sizeMb = 10240
+# mountPath = "/"
 
 # Volume templates (optional)
 # directory = "."

--- a/cli/core/create.go
+++ b/cli/core/create.go
@@ -67,8 +67,8 @@ func runCreateFlow(
 	successFunc func(opts TemplateOptions),
 ) {
 	// Accept shorthand template names without the "template-" prefix
-	if templateNameFlag != "" && !strings.HasPrefix(templateNameFlag, "template-") {
-		templateNameFlag = "template-" + templateNameFlag
+	if templateNameFlag != "" {
+		templateNameFlag = normalizeTemplateNameFlag(templateNameFlag, cfg.TemplateType)
 	}
 	if dirArg == "" {
 		dirArg = generateRandomDirectoryName(cfg.TemplateType)
@@ -104,26 +104,7 @@ func runCreateFlow(
 		opts = CreateDefaultTemplateOptions(selectedDir, templateNameFlag, templates)
 		if opts.TemplateName == "" {
 			PrintError(cfg.ErrorPrefix, fmt.Errorf("template '%s' not found", templateNameFlag))
-			fmt.Println("Available templates:")
-			langs := templates.GetLanguages()
-			for _, lang := range langs {
-				hasTemplates := false
-				for _, t := range templates {
-					if t.Language != lang {
-						continue
-					}
-					if !hasTemplates {
-						fmt.Printf("- %s:\n", lang)
-						hasTemplates = true
-					}
-					name := strings.TrimPrefix(templateDisplayName(t), "template-")
-					if t.Description != "" {
-						fmt.Printf("  - %-30s %s\n", name, t.Description)
-					} else {
-						fmt.Printf("  - %s\n", name)
-					}
-				}
-			}
+			printAvailableTemplates(templates, cfg.TemplateType)
 			return
 		}
 	case cfg.NoTTY && cfg.TemplateType == "mcp":
@@ -154,6 +135,13 @@ func runCreateFlow(
 
 	CleanTemplate(opts.Directory)
 
+	if cfg.TemplateType == "sandbox" {
+		if err := FinalizeSandboxTemplate(opts); err != nil {
+			PrintError(cfg.ErrorPrefix, err)
+			return
+		}
+	}
+
 	// Optionally update blaxel.toml (only for those commands that did previously)
 	if cfg.BlaxelTomlResourceType != "" {
 		_ = EditBlaxelTomlInCurrentDir(cfg.BlaxelTomlResourceType, opts.ProjectName, opts.Directory)
@@ -183,8 +171,60 @@ func runCreateFlow(
 	successFunc(opts)
 }
 
+func normalizeTemplateNameFlag(templateNameFlag string, templateType string) string {
+	if templateType == "sandbox" {
+		if templateName, ok := sandboxTemplateAlias(templateNameFlag); ok {
+			return templateName
+		}
+	}
+	if !strings.HasPrefix(templateNameFlag, "template-") {
+		return "template-" + templateNameFlag
+	}
+	return templateNameFlag
+}
+
 func templateDisplayName(t Template) string {
 	return regexp.MustCompile(`^\d+-`).ReplaceAllString(t.Name, "")
+}
+
+func printAvailableTemplates(templates Templates, templateType string) {
+	fmt.Println("Available templates:")
+	if templateType == "sandbox" {
+		for _, t := range sandboxTemplatesForDisplay(templates) {
+			printSandboxTemplateLine(t)
+		}
+		return
+	}
+
+	langs := templates.GetLanguages()
+	if len(langs) == 0 {
+		for _, t := range templates {
+			printTemplateLine(t)
+		}
+		return
+	}
+	for _, lang := range langs {
+		hasTemplates := false
+		for _, t := range templates {
+			if t.Language != lang {
+				continue
+			}
+			if !hasTemplates {
+				fmt.Printf("- %s:\n", lang)
+				hasTemplates = true
+			}
+			printTemplateLine(t)
+		}
+	}
+}
+
+func printTemplateLine(t Template) {
+	name := strings.TrimPrefix(templateDisplayName(t), "template-")
+	if t.Description != "" {
+		fmt.Printf("  - %-30s %s\n", name, t.Description)
+	} else {
+		fmt.Printf("  - %s\n", name)
+	}
 }
 
 // PromptTemplateOptions presents a unified interactive form to collect
@@ -363,7 +403,7 @@ func RunSandboxCreation(dirArg string, templateName string, noTTY bool) {
 			SpinnerTitle: "Creating your blaxel sandbox...",
 		},
 		func(directory string, templates Templates) TemplateOptions {
-			return PromptTemplateOptions(directory, templates, "sandbox", false, 5)
+			return PromptSandboxTemplateOptions(directory, templates)
 		},
 		func(opts TemplateOptions) {
 			PrintSuccess("Your blaxel sandbox has been created successfully!")

--- a/cli/core/create.go
+++ b/cli/core/create.go
@@ -51,6 +51,44 @@ type CreateFlowConfig struct {
 	BlaxelTomlResourceType string
 }
 
+type createFlowDeps struct {
+	RetrieveTemplates func(templateType string, noTTY bool, errorPrefix string) (Templates, error)
+	CloneTemplate     func(opts TemplateOptions, templates Templates, noTTY bool, errorPrefix string, spinnerTitle string) error
+	CleanTemplate     func(directory string)
+	EditBlaxelToml    func(resourceType string, projectName string, directory string) error
+	OutputFormat      func() string
+}
+
+func defaultCreateFlowDeps() createFlowDeps {
+	return createFlowDeps{
+		RetrieveTemplates: RetrieveTemplatesWithSpinner,
+		CloneTemplate:     CloneTemplateWithSpinner,
+		CleanTemplate:     CleanTemplate,
+		EditBlaxelToml:    EditBlaxelTomlInCurrentDir,
+		OutputFormat:      GetOutputFormat,
+	}
+}
+
+func fillCreateFlowDeps(deps createFlowDeps) createFlowDeps {
+	defaults := defaultCreateFlowDeps()
+	if deps.RetrieveTemplates == nil {
+		deps.RetrieveTemplates = defaults.RetrieveTemplates
+	}
+	if deps.CloneTemplate == nil {
+		deps.CloneTemplate = defaults.CloneTemplate
+	}
+	if deps.CleanTemplate == nil {
+		deps.CleanTemplate = defaults.CleanTemplate
+	}
+	if deps.EditBlaxelToml == nil {
+		deps.EditBlaxelToml = defaults.EditBlaxelToml
+	}
+	if deps.OutputFormat == nil {
+		deps.OutputFormat = defaults.OutputFormat
+	}
+	return deps
+}
+
 // runCreateFlow centralizes the common steps for all create-* commands while
 // preserving each command's specific behavior via the config and callbacks.
 //
@@ -66,6 +104,21 @@ func runCreateFlow(
 	promptFunc func(directory string, templates Templates) TemplateOptions,
 	successFunc func(opts TemplateOptions),
 ) {
+	if err := runCreateFlowWithDeps(dirArg, templateNameFlag, cfg, promptFunc, successFunc, defaultCreateFlowDeps()); err != nil {
+		ExitWithError(err)
+	}
+}
+
+func runCreateFlowWithDeps(
+	dirArg string,
+	templateNameFlag string,
+	cfg CreateFlowConfig,
+	promptFunc func(directory string, templates Templates) TemplateOptions,
+	successFunc func(opts TemplateOptions),
+	deps createFlowDeps,
+) error {
+	deps = fillCreateFlowDeps(deps)
+
 	// Accept shorthand template names without the "template-" prefix
 	if templateNameFlag != "" && !strings.HasPrefix(templateNameFlag, "template-") {
 		templateNameFlag = "template-" + templateNameFlag
@@ -77,15 +130,16 @@ func runCreateFlow(
 	// If directory arg provided, ensure it doesn't already exist
 	if dirArg != "" {
 		if _, err := os.Stat(dirArg); !os.IsNotExist(err) {
-			PrintError(cfg.ErrorPrefix, fmt.Errorf("directory '%s' already exists", dirArg))
-			return
+			createErr := fmt.Errorf("directory '%s' already exists", dirArg)
+			PrintError(cfg.ErrorPrefix, createErr)
+			return createErr
 		}
 	}
 
 	// Retrieve templates (with or without spinner)
-	templates, err := RetrieveTemplatesWithSpinner(cfg.TemplateType, cfg.NoTTY, cfg.ErrorPrefix)
+	templates, err := deps.RetrieveTemplates(cfg.TemplateType, cfg.NoTTY, cfg.ErrorPrefix)
 	if err != nil {
-		ExitWithError(err)
+		return err
 	}
 
 	// Resolve options
@@ -98,13 +152,15 @@ func runCreateFlow(
 			selectedDir = templateNameFlag
 		}
 		if _, err := os.Stat(selectedDir); !os.IsNotExist(err) {
-			PrintError(cfg.ErrorPrefix, fmt.Errorf("directory '%s' already exists", selectedDir))
-			return
+			createErr := fmt.Errorf("directory '%s' already exists", selectedDir)
+			PrintError(cfg.ErrorPrefix, createErr)
+			return createErr
 		}
 		opts = CreateDefaultTemplateOptions(selectedDir, templateNameFlag, templates)
 		if opts.TemplateName == "" {
-			PrintError(cfg.ErrorPrefix, fmt.Errorf("template '%s' not found", templateNameFlag))
-			fmt.Println("Available templates:")
+			createErr := fmt.Errorf("template '%s' not found", templateNameFlag)
+			PrintError(cfg.ErrorPrefix, createErr)
+			PrintDiagnostic("Available templates:")
 			langs := templates.GetLanguages()
 			for _, lang := range langs {
 				hasTemplates := false
@@ -113,24 +169,25 @@ func runCreateFlow(
 						continue
 					}
 					if !hasTemplates {
-						fmt.Printf("- %s:\n", lang)
+						PrintDiagnostic(fmt.Sprintf("- %s:", lang))
 						hasTemplates = true
 					}
 					name := strings.TrimPrefix(templateDisplayName(t), "template-")
 					if t.Description != "" {
-						fmt.Printf("  - %-30s %s\n", name, t.Description)
+						PrintDiagnostic(fmt.Sprintf("  - %-30s %s", name, t.Description))
 					} else {
-						fmt.Printf("  - %s\n", name)
+						PrintDiagnostic(fmt.Sprintf("  - %s", name))
 					}
 				}
 			}
-			return
+			return createErr
 		}
 	case cfg.NoTTY && cfg.TemplateType == "mcp":
 		// Special-case retained behavior: for MCP with --yes but no template we require directory and pick default
 		if dirArg == "" {
-			PrintError(cfg.ErrorPrefix, fmt.Errorf("directory name is required"))
-			return
+			createErr := fmt.Errorf("directory name is required")
+			PrintError(cfg.ErrorPrefix, createErr)
+			return createErr
 		}
 		opts = CreateDefaultTemplateOptions(dirArg, "", templates)
 	default:
@@ -138,29 +195,34 @@ func runCreateFlow(
 		opts = promptFunc(dirArg, templates)
 		// Safety checks
 		if opts.Directory == "" {
-			PrintError(cfg.ErrorPrefix, fmt.Errorf("directory name is required"))
-			return
+			createErr := fmt.Errorf("directory name is required")
+			PrintError(cfg.ErrorPrefix, createErr)
+			return createErr
 		}
 		if _, err := os.Stat(opts.Directory); !os.IsNotExist(err) {
-			PrintError(cfg.ErrorPrefix, fmt.Errorf("directory '%s' already exists", opts.Directory))
-			return
+			createErr := fmt.Errorf("directory '%s' already exists", opts.Directory)
+			PrintError(cfg.ErrorPrefix, createErr)
+			return createErr
 		}
 	}
 
 	// Clone template using the unified helper
-	if err := CloneTemplateWithSpinner(opts, templates, cfg.NoTTY, cfg.ErrorPrefix, cfg.SpinnerTitle); err != nil {
-		return
+	if err := deps.CloneTemplate(opts, templates, cfg.NoTTY, cfg.ErrorPrefix, cfg.SpinnerTitle); err != nil {
+		return err
 	}
 
-	CleanTemplate(opts.Directory)
+	deps.CleanTemplate(opts.Directory)
 
 	// Optionally update blaxel.toml (only for those commands that did previously)
 	if cfg.BlaxelTomlResourceType != "" {
-		_ = EditBlaxelTomlInCurrentDir(cfg.BlaxelTomlResourceType, opts.ProjectName, opts.Directory)
+		if err := deps.EditBlaxelToml(cfg.BlaxelTomlResourceType, opts.ProjectName, opts.Directory); err != nil {
+			PrintError(cfg.ErrorPrefix, err)
+			return err
+		}
 	}
 
 	// If structured output is requested, print JSON/YAML and skip the regular success message
-	outputFmt := GetOutputFormat()
+	outputFmt := deps.OutputFormat()
 	if outputFmt == "json" || outputFmt == "yaml" {
 		result := map[string]string{
 			"directory": opts.Directory,
@@ -176,11 +238,12 @@ func runCreateFlow(
 			data, _ := yaml.Marshal(result)
 			fmt.Print(string(data))
 		}
-		return
+		return nil
 	}
 
 	// Let the caller print specific success instructions
 	successFunc(opts)
+	return nil
 }
 
 func templateDisplayName(t Template) string {

--- a/cli/core/create_test.go
+++ b/cli/core/create_test.go
@@ -1,11 +1,14 @@
 package core
 
 import (
+	"os"
+	"path/filepath"
 	"regexp"
 	"testing"
 
 	blaxel "github.com/blaxel-ai/sdk-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateRandomDirectoryName(t *testing.T) {
@@ -137,4 +140,194 @@ func TestTemplateDisplayNameRegex(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestNormalizeTemplateNameFlag(t *testing.T) {
+	tests := []struct {
+		name         string
+		templateType string
+		input        string
+		expected     string
+	}{
+		{
+			name:         "keeps non-sandbox full template name",
+			templateType: "agent",
+			input:        "template-google-adk-py",
+			expected:     "template-google-adk-py",
+		},
+		{
+			name:         "prefixes non-sandbox shorthand",
+			templateType: "agent",
+			input:        "google-adk-py",
+			expected:     "template-google-adk-py",
+		},
+		{
+			name:         "maps scratch sandbox alias",
+			templateType: "sandbox",
+			input:        "scratch",
+			expected:     sandboxScratchTemplate,
+		},
+		{
+			name:         "maps claude code sandbox alias",
+			templateType: "sandbox",
+			input:        "claude-code",
+			expected:     sandboxClaudeCodeTemplate,
+		},
+		{
+			name:         "maps codex sandbox alias",
+			templateType: "sandbox",
+			input:        "codex",
+			expected:     sandboxCodexTemplate,
+		},
+		{
+			name:         "keeps legacy sandbox template reachable",
+			templateType: "sandbox",
+			input:        "sandbox-codegen",
+			expected:     "template-sandbox-codegen",
+		},
+		{
+			name:         "keeps full sandbox template name reachable",
+			templateType: "sandbox",
+			input:        "template-sandbox-codegen",
+			expected:     "template-sandbox-codegen",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, normalizeTemplateNameFlag(tt.input, tt.templateType))
+		})
+	}
+}
+
+func TestSandboxTemplatesForDisplay(t *testing.T) {
+	templates := Templates{
+		{Template: blaxel.Template{Name: "template-sandbox-codegen"}},
+		{Template: blaxel.Template{Name: sandboxCodexTemplate}},
+		{Template: blaxel.Template{Name: sandboxScratchTemplate}},
+		{Template: blaxel.Template{Name: sandboxClaudeCodeTemplate}},
+	}
+
+	displayTemplates := sandboxTemplatesForDisplay(templates)
+
+	assert.Equal(t, []string{
+		sandboxScratchTemplate,
+		sandboxClaudeCodeTemplate,
+		sandboxCodexTemplate,
+	}, []string{
+		displayTemplates[0].Name,
+		displayTemplates[1].Name,
+		displayTemplates[2].Name,
+	})
+}
+
+func TestSandboxTemplatesForDisplayFallsBackToAvailableTemplates(t *testing.T) {
+	templates := Templates{
+		{Template: blaxel.Template{Name: "template-sandbox-codegen"}},
+	}
+
+	displayTemplates := sandboxTemplatesForDisplay(templates)
+
+	assert.Len(t, displayTemplates, 1)
+	assert.Equal(t, "template-sandbox-codegen", displayTemplates[0].Name)
+}
+
+func TestSandboxTemplateLabelsAndFlagNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		template Template
+		label    string
+		flagName string
+	}{
+		{
+			name:     "scratch",
+			template: Template{Template: blaxel.Template{Name: sandboxScratchTemplate}},
+			label:    "Scratch",
+			flagName: "scratch",
+		},
+		{
+			name:     "claude code",
+			template: Template{Template: blaxel.Template{Name: sandboxClaudeCodeTemplate}},
+			label:    "Claude Code",
+			flagName: "claude-code",
+		},
+		{
+			name:     "codex",
+			template: Template{Template: blaxel.Template{Name: sandboxCodexTemplate}},
+			label:    "Codex",
+			flagName: "codex",
+		},
+		{
+			name:     "legacy fallback",
+			template: Template{Template: blaxel.Template{Name: "template-sandbox-codegen"}},
+			label:    "sandbox-codegen",
+			flagName: "sandbox-codegen",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.label, sandboxTemplateLabel(tt.template))
+			assert.Equal(t, tt.flagName, sandboxTemplateFlagName(tt.template))
+		})
+	}
+}
+
+func TestFinalizeSandboxTemplateWritesClaudeCodeRuntimeFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	require.NoError(t, FinalizeSandboxTemplate(TemplateOptions{
+		Directory:    tempDir,
+		TemplateName: sandboxClaudeCodeTemplate,
+	}))
+
+	dockerfile, err := os.ReadFile(filepath.Join(tempDir, "Dockerfile"))
+	require.NoError(t, err)
+	assert.Contains(t, string(dockerfile), "npm install -g @anthropic-ai/claude-code@latest")
+	assert.Contains(t, string(dockerfile), `ENV PATH="/usr/local/bin:/app/node_modules/.bin:$PATH"`)
+	assert.Contains(t, string(dockerfile), "ripgrep")
+
+	readme, err := os.ReadFile(filepath.Join(tempDir, "README.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(readme), "bl new sandbox my-sandbox -t claude-code -y")
+	assert.Contains(t, string(readme), "claude --version")
+
+	makefile, err := os.ReadFile(filepath.Join(tempDir, "Makefile"))
+	require.NoError(t, err)
+	assert.Contains(t, string(makefile), "blaxel-sandbox-claude-code")
+}
+
+func TestFinalizeSandboxTemplateWritesCodexRuntimeFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	require.NoError(t, FinalizeSandboxTemplate(TemplateOptions{
+		Directory:    tempDir,
+		TemplateName: sandboxCodexTemplate,
+	}))
+
+	dockerfile, err := os.ReadFile(filepath.Join(tempDir, "Dockerfile"))
+	require.NoError(t, err)
+	assert.Contains(t, string(dockerfile), "npm install -g @openai/codex@latest")
+	assert.Contains(t, string(dockerfile), `ENV PATH="/usr/local/bin:/app/node_modules/.bin:$PATH"`)
+
+	readme, err := os.ReadFile(filepath.Join(tempDir, "README.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(readme), "bl new sandbox my-sandbox -t codex -y")
+	assert.Contains(t, string(readme), "codex --version")
+}
+
+func TestFinalizeSandboxTemplateWritesScratchRuntimeFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	require.NoError(t, FinalizeSandboxTemplate(TemplateOptions{
+		Directory:    tempDir,
+		TemplateName: sandboxScratchTemplate,
+	}))
+
+	dockerfile, err := os.ReadFile(filepath.Join(tempDir, "Dockerfile"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(dockerfile), "@anthropic-ai/claude-code")
+	assert.NotContains(t, string(dockerfile), "@openai/codex")
+
+	readme, err := os.ReadFile(filepath.Join(tempDir, "README.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(readme), "bl new sandbox my-sandbox -t scratch -y")
+	assert.NotContains(t, string(readme), "--version")
 }

--- a/cli/core/create_test.go
+++ b/cli/core/create_test.go
@@ -331,3 +331,46 @@ func TestFinalizeSandboxTemplateWritesScratchRuntimeFiles(t *testing.T) {
 	assert.Contains(t, string(readme), "bl new sandbox my-sandbox -t scratch -y")
 	assert.NotContains(t, string(readme), "--version")
 }
+
+func TestFinalizeSandboxTemplatePreservesLowercaseDockerfileWhenOnlyLowercaseExists(t *testing.T) {
+	tempDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "dockerfile"), []byte("old lower"), 0644))
+	if _, err := os.Stat(filepath.Join(tempDir, "Dockerfile")); err == nil {
+		t.Skip("case-insensitive filesystem treats Dockerfile and dockerfile as the same path")
+	}
+	require.NoError(t, FinalizeSandboxTemplate(TemplateOptions{
+		Directory:    tempDir,
+		TemplateName: sandboxCodexTemplate,
+	}))
+
+	lowercaseDockerfile, err := os.ReadFile(filepath.Join(tempDir, "dockerfile"))
+	require.NoError(t, err)
+	assert.Contains(t, string(lowercaseDockerfile), "npm install -g @openai/codex@latest")
+
+	_, err = os.Stat(filepath.Join(tempDir, "Dockerfile"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestFinalizeSandboxTemplateRemovesDuplicateLowercaseDockerfile(t *testing.T) {
+	tempDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "Dockerfile"), []byte("old upper"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "dockerfile"), []byte("old lower"), 0644))
+	upperInfo, err := os.Stat(filepath.Join(tempDir, "Dockerfile"))
+	require.NoError(t, err)
+	lowerInfo, err := os.Stat(filepath.Join(tempDir, "dockerfile"))
+	require.NoError(t, err)
+	if os.SameFile(upperInfo, lowerInfo) {
+		t.Skip("case-insensitive filesystem treats Dockerfile and dockerfile as the same path")
+	}
+
+	require.NoError(t, FinalizeSandboxTemplate(TemplateOptions{
+		Directory:    tempDir,
+		TemplateName: sandboxClaudeCodeTemplate,
+	}))
+
+	_, err = os.Stat(filepath.Join(tempDir, "dockerfile"))
+	assert.True(t, os.IsNotExist(err))
+	dockerfile, err := os.ReadFile(filepath.Join(tempDir, "Dockerfile"))
+	require.NoError(t, err)
+	assert.Contains(t, string(dockerfile), "npm install -g @anthropic-ai/claude-code@latest")
+}

--- a/cli/core/create_test.go
+++ b/cli/core/create_test.go
@@ -1,11 +1,14 @@
 package core
 
 import (
+	"errors"
+	"path/filepath"
 	"regexp"
 	"testing"
 
 	blaxel "github.com/blaxel-ai/sdk-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateRandomDirectoryName(t *testing.T) {
@@ -137,4 +140,115 @@ func TestTemplateDisplayNameRegex(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestRunCreateFlowWithDepsReturnsErrorWhenDirectoryExists(t *testing.T) {
+	existingDir := t.TempDir()
+
+	err := runCreateFlowWithDeps(
+		existingDir,
+		"google-adk-py",
+		CreateFlowConfig{
+			TemplateType: "agent",
+			NoTTY:        true,
+			ErrorPrefix:  "Agent creation",
+			SpinnerTitle: "Creating your blaxel agent app...",
+		},
+		func(directory string, templates Templates) TemplateOptions {
+			t.Fatal("prompt should not run for an existing directory")
+			return TemplateOptions{}
+		},
+		func(opts TemplateOptions) {
+			t.Fatal("success should not run after an existing directory error")
+		},
+		createFlowDeps{},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+}
+
+func TestRunCreateFlowWithDepsReturnsErrorWhenTemplateNotFound(t *testing.T) {
+	var err error
+	stdout, stderr := captureStandardStreams(t, func() {
+		err = runCreateFlowWithDeps(
+			filepath.Join(t.TempDir(), "new-agent"),
+			"missing-template",
+			CreateFlowConfig{
+				TemplateType: "agent",
+				NoTTY:        true,
+				ErrorPrefix:  "Agent creation",
+				SpinnerTitle: "Creating your blaxel agent app...",
+			},
+			func(directory string, templates Templates) TemplateOptions {
+				t.Fatal("prompt should not run when a template flag is provided")
+				return TemplateOptions{}
+			},
+			func(opts TemplateOptions) {
+				t.Fatal("success should not run when template resolution fails")
+			},
+			createFlowDeps{
+				RetrieveTemplates: func(templateType string, noTTY bool, errorPrefix string) (Templates, error) {
+					return Templates{
+						{
+							Template: blaxel.Template{Name: "template-google-adk-py"},
+							Language: "python",
+							Type:     "agent",
+						},
+					}, nil
+				},
+			},
+		)
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "template 'template-missing-template' not found")
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "Available templates:")
+	assert.Contains(t, stderr, "google-adk-py")
+}
+
+func TestRunCreateFlowWithDepsReturnsCloneFailure(t *testing.T) {
+	cloneErr := errors.New("dependency install failed")
+	cleanCalled := false
+	successCalled := false
+
+	err := runCreateFlowWithDeps(
+		filepath.Join(t.TempDir(), "new-agent"),
+		"google-adk-py",
+		CreateFlowConfig{
+			TemplateType: "agent",
+			NoTTY:        true,
+			ErrorPrefix:  "Agent creation",
+			SpinnerTitle: "Creating your blaxel agent app...",
+		},
+		func(directory string, templates Templates) TemplateOptions {
+			t.Fatal("prompt should not run when a template flag is provided")
+			return TemplateOptions{}
+		},
+		func(opts TemplateOptions) {
+			successCalled = true
+		},
+		createFlowDeps{
+			RetrieveTemplates: func(templateType string, noTTY bool, errorPrefix string) (Templates, error) {
+				return Templates{
+					{
+						Template: blaxel.Template{Name: "template-google-adk-py"},
+						Language: "python",
+						Type:     "agent",
+					},
+				}, nil
+			},
+			CloneTemplate: func(opts TemplateOptions, templates Templates, noTTY bool, errorPrefix string, spinnerTitle string) error {
+				return cloneErr
+			},
+			CleanTemplate: func(directory string) {
+				cleanCalled = true
+			},
+		},
+	)
+
+	require.ErrorIs(t, err, cloneErr)
+	assert.False(t, cleanCalled)
+	assert.False(t, successCalled)
 }

--- a/cli/core/create_test.go
+++ b/cli/core/create_test.go
@@ -332,6 +332,33 @@ func TestFinalizeSandboxTemplateWritesScratchRuntimeFiles(t *testing.T) {
 	assert.NotContains(t, string(readme), "--version")
 }
 
+func TestFinalizeSandboxTemplateRejectsSymlinkRuntimeFiles(t *testing.T) {
+	for _, name := range []string{"Dockerfile", "Makefile", "entrypoint.sh", "README.md"} {
+		t.Run(name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			outsideDir := t.TempDir()
+			outsidePath := filepath.Join(outsideDir, "outside.txt")
+			require.NoError(t, os.WriteFile(outsidePath, []byte("keep me"), 0644))
+
+			err := os.Symlink(outsidePath, filepath.Join(tempDir, name))
+			if err != nil {
+				t.Skipf("symlinks are not available: %v", err)
+			}
+
+			err = FinalizeSandboxTemplate(TemplateOptions{
+				Directory:    tempDir,
+				TemplateName: sandboxClaudeCodeTemplate,
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "refusing to write "+name)
+
+			outsideContent, readErr := os.ReadFile(outsidePath)
+			require.NoError(t, readErr)
+			assert.Equal(t, "keep me", string(outsideContent))
+		})
+	}
+}
+
 func TestFinalizeSandboxTemplatePreservesLowercaseDockerfileWhenOnlyLowercaseExists(t *testing.T) {
 	tempDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "dockerfile"), []byte("old lower"), 0644))

--- a/cli/core/root.go
+++ b/cli/core/root.go
@@ -104,7 +104,7 @@ func writeVersionCache(cache versionCache) error {
 }
 
 func notifyNewVersionAvailable(latestVersion, currentVersion string) {
-	fmt.Printf("%s⚠️  A new version of Blaxel CLI is available: %s%s%s%s (current: %s%s%s)\n%sYou can update by running: %sbl upgrade%s\n%sOr follow the instructions at %s%s%s\n\n%s",
+	fmt.Fprintf(os.Stderr, "%s⚠️  A new version of Blaxel CLI is available: %s%s%s%s (current: %s%s%s)\n%sYou can update by running: %sbl upgrade%s\n%sOr follow the instructions at %s%s%s\n\n%s",
 		colorYellow, colorBold+colorGreen, latestVersion, colorReset, colorYellow, colorBold, currentVersion, colorReset+colorYellow,
 		colorYellow, colorBold+colorGreen, colorReset+colorYellow,
 		colorYellow, colorCyan, UPDATE_CLI_DOC_URL, colorReset+colorYellow, colorReset)

--- a/cli/core/root_test.go
+++ b/cli/core/root_test.go
@@ -169,6 +169,16 @@ func TestVersionCache(t *testing.T) {
 	})
 }
 
+func TestNotifyNewVersionAvailableWritesToStderr(t *testing.T) {
+	stdout, stderr := captureStandardStreams(t, func() {
+		notifyNewVersionAvailable("0.1.93", "0.1.92")
+	})
+
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "A new version of Blaxel CLI is available")
+	assert.Contains(t, stderr, "bl upgrade")
+}
+
 func TestGetConfig(t *testing.T) {
 	// Save original and restore
 	original := config

--- a/cli/core/sandbox_templates.go
+++ b/cli/core/sandbox_templates.go
@@ -1,0 +1,382 @@
+package core
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	blaxel "github.com/blaxel-ai/sdk-go"
+	"github.com/charmbracelet/huh"
+)
+
+const (
+	sandboxScratchTemplate    = "template-sandbox-scratch"
+	sandboxClaudeCodeTemplate = "template-sandbox-claude-code"
+	sandboxCodexTemplate      = "template-sandbox-codex"
+	sandboxCodegenTemplate    = "template-sandbox-codegen"
+
+	sandboxCodegenTemplateURL    = "https://github.com/blaxel-templates/template-sandbox-codegen.git"
+	sandboxClaudeCodeTemplateURL = "https://github.com/blaxel-templates/template-sandbox-claude-code.git"
+)
+
+func ensureSandboxTemplates(templates Templates) Templates {
+	existing := map[string]bool{}
+	for _, template := range templates {
+		existing[template.Name] = true
+	}
+
+	baseURL := sandboxTemplateURL(templates, sandboxCodegenTemplate)
+	if baseURL == "" {
+		baseURL = sandboxCodegenTemplateURL
+	}
+
+	additions := Templates{}
+	for _, template := range []Template{
+		sandboxCatalogTemplate(sandboxScratchTemplate, "Scratch sandbox", "Start from a basic sandbox workspace.", baseURL),
+		sandboxCatalogTemplate(sandboxClaudeCodeTemplate, "Claude Code sandbox", "Sandbox with Claude Code available as claude on PATH.", sandboxClaudeCodeTemplateURL),
+		sandboxCatalogTemplate(sandboxCodexTemplate, "Codex sandbox", "Sandbox with Codex available as codex on PATH.", baseURL),
+	} {
+		if !existing[template.Name] {
+			additions = append(additions, template)
+		}
+	}
+
+	return append(additions, templates...)
+}
+
+func sandboxTemplateURL(templates Templates, name string) string {
+	for _, template := range templates {
+		if template.Name == name {
+			return template.URL
+		}
+	}
+	return ""
+}
+
+func sandboxCatalogTemplate(name string, description string, longDescription string, url string) Template {
+	return Template{
+		Template: blaxel.Template{
+			Name:        name,
+			Description: fmt.Sprintf("%s. %s", description, longDescription),
+			URL:         url,
+			Topics:      []string{"sandbox"},
+		},
+		Type: "sandbox",
+	}
+}
+
+func sandboxTemplateAlias(templateNameFlag string) (string, bool) {
+	key := strings.TrimPrefix(strings.ToLower(templateNameFlag), "template-")
+	switch key {
+	case "scratch", "sandbox-scratch":
+		return sandboxScratchTemplate, true
+	case "claude", "claude-code", "sandbox-claude-code":
+		return sandboxClaudeCodeTemplate, true
+	case "codex", "sandbox-codex":
+		return sandboxCodexTemplate, true
+	default:
+		return "", false
+	}
+}
+
+func printSandboxTemplateLine(t Template) {
+	name := sandboxTemplateFlagName(t)
+	if t.Description != "" {
+		fmt.Printf("  - %-30s %s\n", name, t.Description)
+	} else {
+		fmt.Printf("  - %s\n", name)
+	}
+}
+
+func sandboxTemplateFlagName(t Template) string {
+	switch t.Name {
+	case sandboxScratchTemplate:
+		return "scratch"
+	case sandboxClaudeCodeTemplate:
+		return "claude-code"
+	case sandboxCodexTemplate:
+		return "codex"
+	default:
+		return strings.TrimPrefix(templateDisplayName(t), "template-")
+	}
+}
+
+type sandboxTemplateVariant struct {
+	title       string
+	flagName    string
+	description string
+	imageName   string
+	packageName string
+	commandName string
+}
+
+func sandboxTemplateVariantFor(templateName string) (sandboxTemplateVariant, bool) {
+	switch templateName {
+	case sandboxScratchTemplate:
+		return sandboxTemplateVariant{
+			title:       "Scratch",
+			flagName:    "scratch",
+			description: "A basic Blaxel sandbox with a Next.js workspace and the sandbox API.",
+			imageName:   "blaxel-sandbox-scratch",
+		}, true
+	case sandboxClaudeCodeTemplate:
+		return sandboxTemplateVariant{
+			title:       "Claude Code",
+			flagName:    "claude-code",
+			description: "A Blaxel sandbox with Claude Code installed and available on PATH as `claude`.",
+			imageName:   "blaxel-sandbox-claude-code",
+			packageName: "@anthropic-ai/claude-code",
+			commandName: "claude",
+		}, true
+	case sandboxCodexTemplate:
+		return sandboxTemplateVariant{
+			title:       "Codex",
+			flagName:    "codex",
+			description: "A Blaxel sandbox with Codex installed and available on PATH as `codex`.",
+			imageName:   "blaxel-sandbox-codex",
+			packageName: "@openai/codex",
+			commandName: "codex",
+		}, true
+	default:
+		return sandboxTemplateVariant{}, false
+	}
+}
+
+func PromptSandboxTemplateOptions(directory string, templates Templates) TemplateOptions {
+	options := TemplateOptions{
+		ProjectName:  directory,
+		Directory:    directory,
+		TemplateName: "",
+	}
+
+	currentUser, err := user.Current()
+	if err == nil {
+		options.Author = currentUser.Username
+	} else {
+		options.Author = "blaxel"
+	}
+
+	fields := []huh.Field{}
+	if directory == "" {
+		fields = append(fields, huh.NewInput().
+			Title("Name").
+			Description("Name of your sandbox").
+			Value(&options.Directory),
+		)
+	}
+
+	templateOptions := []huh.Option[string]{}
+	for _, t := range sandboxTemplatesForDisplay(templates) {
+		templateOptions = append(templateOptions, huh.NewOption(sandboxTemplateLabel(t), t.Name))
+	}
+
+	tmplSelect := huh.NewSelect[string]().
+		Title("Sandbox type").
+		Description("Choose the sandbox to scaffold.").
+		Options(templateOptions...).
+		Value(&options.TemplateName)
+	if len(templateOptions) > 5 {
+		tmplSelect = tmplSelect.Height(5)
+	}
+	fields = append(fields, tmplSelect)
+
+	form := huh.NewForm(huh.NewGroup(fields...))
+	form.WithTheme(GetHuhTheme())
+	if err := form.Run(); err != nil {
+		os.Exit(0)
+	}
+	options.ProjectName = options.Directory
+	return options
+}
+
+func sandboxTemplatesForDisplay(templates Templates) Templates {
+	knownTemplates := Templates{}
+	remainingTemplates := Templates{}
+
+	for _, name := range []string{sandboxScratchTemplate, sandboxClaudeCodeTemplate, sandboxCodexTemplate} {
+		for _, t := range templates {
+			if t.Name == name {
+				knownTemplates = append(knownTemplates, t)
+				break
+			}
+		}
+	}
+
+	if len(knownTemplates) > 0 {
+		return knownTemplates
+	}
+
+	for _, t := range templates {
+		remainingTemplates = append(remainingTemplates, t)
+	}
+	return remainingTemplates
+}
+
+func sandboxTemplateLabel(t Template) string {
+	switch t.Name {
+	case sandboxScratchTemplate:
+		return "Scratch"
+	case sandboxClaudeCodeTemplate:
+		return "Claude Code"
+	case sandboxCodexTemplate:
+		return "Codex"
+	default:
+		return strings.TrimPrefix(templateDisplayName(t), "template-")
+	}
+}
+
+func FinalizeSandboxTemplate(opts TemplateOptions) error {
+	variant, ok := sandboxTemplateVariantFor(opts.TemplateName)
+	if !ok {
+		return nil
+	}
+
+	if err := writeSandboxDockerfile(opts.Directory, variant); err != nil {
+		return err
+	}
+	if err := writeSandboxMakefile(opts.Directory, variant); err != nil {
+		return err
+	}
+	if err := writeSandboxEntrypoint(opts.Directory); err != nil {
+		return err
+	}
+	return writeSandboxReadme(opts.Directory, variant)
+}
+
+func writeSandboxDockerfile(dir string, variant sandboxTemplateVariant) error {
+	installLine := ""
+	if variant.packageName != "" {
+		installLine = fmt.Sprintf("\n\nRUN npm install -g %s@latest", variant.packageName)
+	}
+
+	content := fmt.Sprintf(`FROM node:22-alpine
+
+RUN apk update && apk add --no-cache \
+  bash \
+  git \
+  curl \
+  netcat-openbsd \
+  ripgrep \
+  && rm -rf /var/cache/apk/*
+
+WORKDIR /app
+
+COPY --from=ghcr.io/blaxel-ai/sandbox:latest /sandbox-api /usr/local/bin/sandbox-api
+
+RUN mkdir -p /app \
+  && npx create-next-app@latest /app --use-npm --typescript --eslint --tailwind --src-dir --app --import-alias "@/*" --no-git --yes --no-turbopack%s
+
+EXPOSE 3000
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENV PATH="/usr/local/bin:/app/node_modules/.bin:$PATH"
+
+ENTRYPOINT ["/entrypoint.sh"]
+`, installLine)
+
+	for _, name := range []string{"Dockerfile", "dockerfile"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+			return fmt.Errorf("failed to write %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func writeSandboxMakefile(dir string, variant sandboxTemplateVariant) error {
+	content := fmt.Sprintf(`build:
+	docker build --platform=linux/amd64 -t %[1]s .
+
+run:
+	docker rm -f %[1]s || true
+	docker run --platform=linux/amd64 -p 8080:8080 -p 3000:3000 --name %[1]s %[1]s
+`, variant.imageName)
+
+	if err := os.WriteFile(filepath.Join(dir, "Makefile"), []byte(content), 0644); err != nil {
+		return fmt.Errorf("failed to write Makefile: %w", err)
+	}
+	return nil
+}
+
+func writeSandboxEntrypoint(dir string) error {
+	content := `#!/bin/sh
+
+export PATH="/usr/local/bin:/app/node_modules/.bin:$PATH"
+
+/usr/local/bin/sandbox-api &
+
+wait_for_port() {
+    port=$1
+    timeout=30
+    count=0
+
+    echo "Waiting for port $port to be available..."
+
+    while ! nc -z 127.0.0.1 "$port"; do
+        sleep 1
+        count=$((count + 1))
+        if [ "$count" -gt "$timeout" ]; then
+            echo "Timeout waiting for port $port"
+            exit 1
+        fi
+    done
+
+    echo "Port $port is now available"
+}
+
+wait_for_port 8080
+
+echo "Running Next.js dev server..."
+curl http://localhost:8080/process -X POST -d '{"workingDir": "/app", "command": "npm run dev -- --port 3000", "waitForCompletion": false}' -H "Content-Type: application/json"
+
+wait
+`
+
+	path := filepath.Join(dir, "entrypoint.sh")
+	if err := os.WriteFile(path, []byte(content), 0755); err != nil {
+		return fmt.Errorf("failed to write entrypoint.sh: %w", err)
+	}
+	return nil
+}
+
+func writeSandboxReadme(dir string, variant sandboxTemplateVariant) error {
+	commandCheck := ""
+	if variant.commandName != "" {
+		commandCheck = fmt.Sprintf("\n# Check the agent CLI inside the sandbox image or connected sandbox\n%s --version\n", variant.commandName)
+	}
+
+	content := fmt.Sprintf(`# Blaxel %s Sandbox
+
+%s
+
+## Quick Start
+
+`+"```bash"+`
+bl new sandbox my-sandbox -t %s -y
+cd my-sandbox
+bl deploy
+bl connect sandbox my-sandbox%s
+`+"```"+`
+
+## Local Docker
+
+`+"```bash"+`
+make build
+make run
+`+"```"+`
+
+## Project Files
+
+- `+"`Dockerfile`"+` builds the sandbox image.
+- `+"`entrypoint.sh`"+` starts the Blaxel sandbox API and the Next.js dev server.
+- `+"`blaxel.toml`"+` configures the Blaxel sandbox runtime.
+`, variant.title, variant.description, variant.flagName, commandCheck)
+
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte(content), 0644); err != nil {
+		return fmt.Errorf("failed to write README.md: %w", err)
+	}
+	return nil
+}

--- a/cli/core/sandbox_templates.go
+++ b/cli/core/sandbox_templates.go
@@ -280,12 +280,12 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 	target, stale := sandboxDockerfileTarget(dir)
 	for _, path := range stale {
-		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		if err := removeSandboxFile(dir, filepath.Base(path)); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("failed to remove duplicate Dockerfile %s: %w", path, err)
 		}
 	}
-	if err := os.WriteFile(target, []byte(content), 0644); err != nil {
-		return fmt.Errorf("failed to write %s: %w", filepath.Base(target), err)
+	if err := writeSandboxFile(dir, filepath.Base(target), []byte(content), 0644); err != nil {
+		return err
 	}
 	return nil
 }
@@ -313,8 +313,56 @@ func sandboxDockerfileTarget(dir string) (string, []string) {
 }
 
 func fileInfo(path string) (os.FileInfo, bool) {
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	return info, err == nil && !info.IsDir()
+}
+
+func removeSandboxFile(dir, name string) error {
+	if err := validateSandboxFileName(name); err != nil {
+		return err
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return fmt.Errorf("failed to open sandbox directory: %w", err)
+	}
+	defer root.Close()
+	return root.Remove(name)
+}
+
+func writeSandboxFile(dir, name string, data []byte, perm os.FileMode) error {
+	if err := validateSandboxFileName(name); err != nil {
+		return err
+	}
+
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return fmt.Errorf("failed to open sandbox directory: %w", err)
+	}
+	defer root.Close()
+
+	info, err := root.Lstat(name)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to write %s: target is a symlink", name)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("refusing to write %s: target is a directory", name)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to inspect %s: %w", name, err)
+	}
+
+	if err := root.WriteFile(name, data, perm); err != nil {
+		return fmt.Errorf("failed to write %s: %w", name, err)
+	}
+	return nil
+}
+
+func validateSandboxFileName(name string) error {
+	if name == "" || name == "." || filepath.IsAbs(name) || name != filepath.Base(name) {
+		return fmt.Errorf("invalid sandbox file target %q", name)
+	}
+	return nil
 }
 
 func writeSandboxMakefile(dir string, variant sandboxTemplateVariant) error {
@@ -326,8 +374,8 @@ run:
 	docker run --platform=linux/amd64 -p 8080:8080 -p 3000:3000 --name %[1]s %[1]s
 `, variant.imageName)
 
-	if err := os.WriteFile(filepath.Join(dir, "Makefile"), []byte(content), 0644); err != nil {
-		return fmt.Errorf("failed to write Makefile: %w", err)
+	if err := writeSandboxFile(dir, "Makefile", []byte(content), 0644); err != nil {
+		return err
 	}
 	return nil
 }
@@ -367,8 +415,8 @@ wait
 `
 
 	path := filepath.Join(dir, "entrypoint.sh")
-	if err := os.WriteFile(path, []byte(content), 0755); err != nil {
-		return fmt.Errorf("failed to write entrypoint.sh: %w", err)
+	if err := writeSandboxFile(dir, filepath.Base(path), []byte(content), 0755); err != nil {
+		return err
 	}
 	return nil
 }
@@ -406,8 +454,8 @@ make run
 - `+"`blaxel.toml`"+` configures the Blaxel sandbox runtime.
 `, variant.title, variant.description, variant.flagName, commandCheck)
 
-	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte(content), 0644); err != nil {
-		return fmt.Errorf("failed to write README.md: %w", err)
+	if err := writeSandboxFile(dir, "README.md", []byte(content), 0644); err != nil {
+		return err
 	}
 	return nil
 }

--- a/cli/core/sandbox_templates.go
+++ b/cli/core/sandbox_templates.go
@@ -278,12 +278,43 @@ ENV PATH="/usr/local/bin:/app/node_modules/.bin:$PATH"
 ENTRYPOINT ["/entrypoint.sh"]
 `, installLine)
 
-	for _, name := range []string{"Dockerfile", "dockerfile"} {
-		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
-			return fmt.Errorf("failed to write %s: %w", name, err)
+	target, stale := sandboxDockerfileTarget(dir)
+	for _, path := range stale {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove duplicate Dockerfile %s: %w", path, err)
 		}
 	}
+	if err := os.WriteFile(target, []byte(content), 0644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", filepath.Base(target), err)
+	}
 	return nil
+}
+
+func sandboxDockerfileTarget(dir string) (string, []string) {
+	upper := filepath.Join(dir, "Dockerfile")
+	lower := filepath.Join(dir, "dockerfile")
+	upperInfo, upperExists := fileInfo(upper)
+	lowerInfo, lowerExists := fileInfo(lower)
+
+	switch {
+	case upperExists:
+		if lowerExists {
+			if os.SameFile(upperInfo, lowerInfo) {
+				return upper, nil
+			}
+			return upper, []string{lower}
+		}
+		return upper, nil
+	case lowerExists:
+		return lower, nil
+	default:
+		return upper, nil
+	}
+}
+
+func fileInfo(path string) (os.FileInfo, bool) {
+	info, err := os.Stat(path)
+	return info, err == nil && !info.IsDir()
 }
 
 func writeSandboxMakefile(dir string, variant sandboxTemplateVariant) error {

--- a/cli/core/templates.go
+++ b/cli/core/templates.go
@@ -77,6 +77,9 @@ func RetrieveTemplates(templateType string) (Templates, error) {
 			}
 		}
 	}
+	if templateType == "sandbox" {
+		templates = ensureSandboxTemplates(templates)
+	}
 	return templates, nil
 }
 

--- a/cli/core/templates_test.go
+++ b/cli/core/templates_test.go
@@ -152,6 +152,65 @@ func TestTemplatesFind(t *testing.T) {
 	})
 }
 
+func TestEnsureSandboxTemplatesAddsLocalCatalogOptions(t *testing.T) {
+	templates := Templates{
+		{
+			Template: blaxel.Template{
+				Name:        sandboxCodegenTemplate,
+				Description: "Existing sandbox template",
+				URL:         sandboxCodegenTemplateURL,
+				Topics:      []string{"sandbox"},
+			},
+			Type: "sandbox",
+		},
+	}
+
+	result := ensureSandboxTemplates(templates)
+
+	assert.Equal(t, []string{
+		sandboxScratchTemplate,
+		sandboxClaudeCodeTemplate,
+		sandboxCodexTemplate,
+		sandboxCodegenTemplate,
+	}, []string{
+		result[0].Name,
+		result[1].Name,
+		result[2].Name,
+		result[3].Name,
+	})
+	assert.Equal(t, sandboxCodegenTemplateURL, result[0].URL)
+	assert.Equal(t, sandboxClaudeCodeTemplateURL, result[1].URL)
+	assert.Equal(t, sandboxCodegenTemplateURL, result[2].URL)
+}
+
+func TestEnsureSandboxTemplatesKeepsRemoteCatalogOptions(t *testing.T) {
+	templates := Templates{
+		{
+			Template: blaxel.Template{
+				Name:        sandboxClaudeCodeTemplate,
+				Description: "Catalog Claude template",
+				URL:         "https://example.com/catalog-claude.git",
+				Topics:      []string{"sandbox"},
+			},
+			Type: "sandbox",
+		},
+	}
+
+	result := ensureSandboxTemplates(templates)
+
+	claudeCount := 0
+	claudeURL := ""
+	for _, template := range result {
+		if template.Name == sandboxClaudeCodeTemplate {
+			claudeCount++
+			claudeURL = template.URL
+		}
+	}
+
+	assert.Equal(t, 1, claudeCount)
+	assert.Equal(t, "https://example.com/catalog-claude.git", claudeURL)
+}
+
 func TestFindNextAvailablePort(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cli/core/utils.go
+++ b/cli/core/utils.go
@@ -362,19 +362,19 @@ func GetHuhTheme() *huh.Theme {
 // PrintError prints a formatted error message with colors
 func PrintError(operation string, err error) {
 	// Print error header with red color and bold
-	Print(fmt.Sprintf("%s %s\n",
+	PrintDiagnostic(fmt.Sprintf("%s %s\n",
 		color.New(color.FgRed, color.Bold).Sprint("✗"),
 		color.New(color.FgRed, color.Bold).Sprintf("%s failed", operation)))
 
 	// Print reason with lighter red color
-	Print(fmt.Sprintf("%s %s\n",
+	PrintDiagnostic(fmt.Sprintf("%s %s\n",
 		color.New(color.FgRed).Sprint("Reason:"),
 		color.New(color.FgWhite).Sprint(err.Error())))
 }
 
 // PrintWarning prints a formatted warning message with colors
 func PrintWarning(message string) {
-	Print(fmt.Sprintf("%s %s\n",
+	PrintDiagnostic(fmt.Sprintf("%s %s\n",
 		color.New(color.FgYellow, color.Bold).Sprint("⚠"),
 		color.New(color.FgYellow).Sprint(message)))
 }
@@ -398,6 +398,11 @@ func PrintInfoWithCommand(message string, command string) {
 		color.New(color.FgBlue, color.Bold).Sprint("ℹ"),
 		color.New(color.FgBlue).Sprint(message),
 		color.New(color.FgWhite, color.Bold).Sprint(command)))
+}
+
+func PrintDiagnostic(message string) {
+	message = strings.TrimSuffix(message, "\n")
+	fmt.Fprintln(os.Stderr, message)
 }
 
 func Print(message string) {

--- a/cli/core/utils_test.go
+++ b/cli/core/utils_test.go
@@ -1,6 +1,9 @@
 package core
 
 import (
+	"bytes"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,6 +11,68 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func captureStandardStreams(t *testing.T, fn func()) (string, string) {
+	t.Helper()
+
+	originalStdout := os.Stdout
+	originalStderr := os.Stderr
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	require.NoError(t, err)
+	stderrReader, stderrWriter, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stdout = stdoutWriter
+	os.Stderr = stderrWriter
+	t.Cleanup(func() {
+		os.Stdout = originalStdout
+		os.Stderr = originalStderr
+	})
+
+	fn()
+
+	os.Stdout = originalStdout
+	os.Stderr = originalStderr
+
+	require.NoError(t, stdoutWriter.Close())
+	require.NoError(t, stderrWriter.Close())
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	_, err = io.Copy(&stdout, stdoutReader)
+	require.NoError(t, err)
+	_, err = io.Copy(&stderr, stderrReader)
+	require.NoError(t, err)
+
+	return stdout.String(), stderr.String()
+}
+
+func TestPrintErrorWritesToStderr(t *testing.T) {
+	originalInteractive := interactiveMode
+	interactiveMode = false
+	t.Cleanup(func() { interactiveMode = originalInteractive })
+
+	stdout, stderr := captureStandardStreams(t, func() {
+		PrintError("Test operation", errors.New("bad input"))
+	})
+
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "Test operation failed")
+	assert.Contains(t, stderr, "bad input")
+}
+
+func TestPrintWarningWritesToStderr(t *testing.T) {
+	originalInteractive := interactiveMode
+	interactiveMode = false
+	t.Cleanup(func() { interactiveMode = originalInteractive })
+
+	stdout, stderr := captureStandardStreams(t, func() {
+		PrintWarning("careful now")
+	})
+
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "careful now")
+}
 
 func TestSlugify(t *testing.T) {
 	tests := []struct {

--- a/cli/createagentapp.go
+++ b/cli/createagentapp.go
@@ -21,7 +21,9 @@ func CreateAgentAppCmd() *cobra.Command {
 		Long:   "This command has been deprecated. Please use 'bl new agent' instead.",
 		Hidden: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			core.PrintError("create-agent-app", fmt.Errorf("this command has been deprecated. Please use 'bl new agent' instead"))
+			err := fmt.Errorf("this command has been deprecated. Please use 'bl new agent' instead")
+			core.PrintError("create-agent-app", err)
+			core.ExitWithError(err)
 		},
 	}
 	return cmd

--- a/cli/createjob.go
+++ b/cli/createjob.go
@@ -21,7 +21,9 @@ func CreateJobCmd() *cobra.Command {
 		Long:   "This command has been deprecated. Please use 'bl new job' instead.",
 		Hidden: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			core.PrintError("create-job", fmt.Errorf("this command has been deprecated. Please use 'bl new job' instead"))
+			err := fmt.Errorf("this command has been deprecated. Please use 'bl new job' instead")
+			core.PrintError("create-job", err)
+			core.ExitWithError(err)
 		},
 	}
 	return cmd

--- a/cli/createmcp.go
+++ b/cli/createmcp.go
@@ -21,7 +21,9 @@ func CreateMCPCmd() *cobra.Command {
 		Long:   "This command has been deprecated. Please use 'bl new mcp' instead.",
 		Hidden: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			core.PrintError("create-mcp", fmt.Errorf("this command has been deprecated. Please use 'bl new mcp' instead"))
+			err := fmt.Errorf("this command has been deprecated. Please use 'bl new mcp' instead")
+			core.PrintError("create-mcp", err)
+			core.ExitWithError(err)
 		},
 	}
 	return cmd

--- a/cli/createsandbox.go
+++ b/cli/createsandbox.go
@@ -22,7 +22,9 @@ func CreateSandboxCmd() *cobra.Command {
 		Long:    "This command has been deprecated. Please use 'bl new sandbox' instead.",
 		Hidden:  true,
 		Run: func(cmd *cobra.Command, args []string) {
-			core.PrintError("create-sandbox", fmt.Errorf("this command has been deprecated. Please use 'bl new sandbox' instead"))
+			err := fmt.Errorf("this command has been deprecated. Please use 'bl new sandbox' instead")
+			core.PrintError("create-sandbox", err)
+			core.ExitWithError(err)
 		},
 	}
 	return cmd

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -282,11 +282,20 @@ all projects in a monorepo (looks for blaxel.toml in subdirectories).`,
 			}
 
 			if dryRun {
-				err := deployment.Print(skipBuild)
-				if err != nil {
-					err = fmt.Errorf("error printing blaxel deployment: %w", err)
-					core.PrintError("Deploy", err)
-					core.ExitWithError(err)
+				if isStructured {
+					err := deployment.printDryRunStructuredOutput(outputFmt, skipBuild)
+					if err != nil {
+						err = fmt.Errorf("error printing structured dry run: %w", err)
+						core.PrintError("Deploy", err)
+						core.ExitWithError(err)
+					}
+				} else {
+					err := deployment.Print(skipBuild)
+					if err != nil {
+						err = fmt.Errorf("error printing blaxel deployment: %w", err)
+						core.PrintError("Deploy", err)
+						core.ExitWithError(err)
+					}
 				}
 				return
 			}
@@ -1631,6 +1640,115 @@ func (d *Deployment) printStructuredOutput(outputFmt string, startTime time.Time
 		data, _ := yaml.Marshal(result)
 		fmt.Print(string(data))
 	}
+}
+
+type dryRunFile struct {
+	Name string `json:"name" yaml:"name"`
+	Size int64  `json:"size" yaml:"size"`
+}
+
+type dryRunResult struct {
+	DryRun    bool          `json:"dryRun" yaml:"dryRun"`
+	Resources []core.Result `json:"resources" yaml:"resources"`
+	Files     []dryRunFile  `json:"files,omitempty" yaml:"files,omitempty"`
+}
+
+func (d *Deployment) printDryRunStructuredOutput(outputFmt string, skipBuild bool) error {
+	data, err := d.renderDryRunStructuredOutput(outputFmt, skipBuild)
+	if err != nil {
+		return err
+	}
+	switch outputFmt {
+	case "json":
+		fmt.Println(string(data))
+	case "yaml":
+		fmt.Print(string(data))
+	}
+	return nil
+}
+
+func (d *Deployment) renderDryRunStructuredOutput(outputFmt string, skipBuild bool) ([]byte, error) {
+	files, err := d.collectDryRunFiles(skipBuild)
+	if err != nil {
+		return nil, err
+	}
+	result := dryRunResult{
+		DryRun:    true,
+		Resources: d.blaxelDeployments,
+		Files:     files,
+	}
+	switch outputFmt {
+	case "json":
+		return json.MarshalIndent(result, "", "  ")
+	case "yaml":
+		return yaml.Marshal(result)
+	default:
+		return nil, fmt.Errorf("unsupported dry-run output format %q", outputFmt)
+	}
+}
+
+func (d *Deployment) collectDryRunFiles(skipBuild bool) ([]dryRunFile, error) {
+	config := core.GetConfig()
+	if skipBuild || config.Image != "" {
+		return nil, nil
+	}
+	if d.archive == nil {
+		return nil, nil
+	}
+	if core.IsVolumeTemplate(config.Type) {
+		return collectDryRunTarFiles(d.archive.Name())
+	}
+	return collectDryRunZipFiles(d.archive.Name())
+}
+
+func collectDryRunZipFiles(path string) ([]dryRunFile, error) {
+	zipFile, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reopen zip file: %w", err)
+	}
+	defer func() { _ = zipFile.Close() }()
+
+	fileInfo, err := zipFile.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get file info: %w", err)
+	}
+	zipReader, err := zip.NewReader(zipFile, fileInfo.Size())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create zip reader: %w", err)
+	}
+	files := make([]dryRunFile, 0, len(zipReader.File))
+	for _, file := range zipReader.File {
+		files = append(files, dryRunFile{
+			Name: file.Name,
+			Size: int64(file.FileInfo().Size()),
+		})
+	}
+	return files, nil
+}
+
+func collectDryRunTarFiles(path string) ([]dryRunFile, error) {
+	tarFile, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reopen tar file: %w", err)
+	}
+	defer func() { _ = tarFile.Close() }()
+
+	tarReader := tar.NewReader(tarFile)
+	var files []dryRunFile
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to read tar header: %w", err)
+		}
+		files = append(files, dryRunFile{
+			Name: header.Name,
+			Size: header.Size,
+		})
+	}
+	return files, nil
 }
 
 func (d *Deployment) Ready() {

--- a/cli/deploy_test.go
+++ b/cli/deploy_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"archive/tar"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,6 +51,49 @@ func TestDeployCmd(t *testing.T) {
 	yesFlag := cmd.Flags().Lookup("yes")
 	assert.NotNil(t, yesFlag)
 	assert.Equal(t, "y", yesFlag.Shorthand)
+}
+
+func TestDeploymentDryRunStructuredOutputJSON(t *testing.T) {
+	deployment := Deployment{
+		blaxelDeployments: []core.Result{
+			{
+				ApiVersion: "blaxel.ai/v1alpha1",
+				Kind:       "Sandbox",
+				Metadata: map[string]interface{}{
+					"name": "pm1729-dryrun",
+				},
+				Spec: map[string]interface{}{
+					"runtime": map[string]interface{}{
+						"image": "ubuntu:latest",
+					},
+				},
+			},
+		},
+	}
+
+	output, err := deployment.renderDryRunStructuredOutput("json", true)
+	require.NoError(t, err)
+
+	var payload struct {
+		DryRun    bool          `json:"dryRun"`
+		Resources []core.Result `json:"resources"`
+		Files     []dryRunFile  `json:"files"`
+	}
+	require.NoError(t, json.Unmarshal(output, &payload))
+	assert.True(t, payload.DryRun)
+	require.Len(t, payload.Resources, 1)
+	assert.Equal(t, "Sandbox", payload.Resources[0].Kind)
+	assert.Empty(t, payload.Files)
+}
+
+func TestDeploymentDryRunStructuredOutputRejectsUnknownFormat(t *testing.T) {
+	deployment := Deployment{}
+
+	output, err := deployment.renderDryRunStructuredOutput("table", true)
+
+	require.Error(t, err)
+	assert.Nil(t, output)
+	assert.Contains(t, err.Error(), "unsupported dry-run output format")
 }
 
 func TestDeploymentStruct(t *testing.T) {

--- a/cli/deprecated_test.go
+++ b/cli/deprecated_test.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeprecatedCreateCommandsExitNonZero(t *testing.T) {
+	commands := []string{
+		"create-agent-app",
+		"create-sandbox",
+		"create-job",
+		"create-mcp",
+	}
+
+	for _, commandName := range commands {
+		t.Run(commandName, func(t *testing.T) {
+			cmd := exec.Command(os.Args[0], "-test.run=TestDeprecatedCreateCommandsExitNonZeroHelper")
+			cmd.Env = append(os.Environ(), "BLAXEL_TEST_DEPRECATED_COMMAND="+commandName)
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+
+			err := cmd.Run()
+
+			require.Error(t, err)
+			var exitErr *exec.ExitError
+			require.ErrorAs(t, err, &exitErr)
+			assert.Equal(t, 1, exitErr.ExitCode())
+			assert.Empty(t, stdout.String())
+			assert.Contains(t, stderr.String(), "deprecated")
+		})
+	}
+}
+
+func TestDeprecatedCreateCommandsExitNonZeroHelper(t *testing.T) {
+	commandName := os.Getenv("BLAXEL_TEST_DEPRECATED_COMMAND")
+	if commandName == "" {
+		t.Skip("helper only runs in a subprocess")
+	}
+
+	var cmd *cobra.Command
+	switch commandName {
+	case "create-agent-app":
+		cmd = CreateAgentAppCmd()
+	case "create-sandbox":
+		cmd = CreateSandboxCmd()
+	case "create-job":
+		cmd = CreateJobCmd()
+	case "create-mcp":
+		cmd = CreateMCPCmd()
+	default:
+		t.Fatalf("unknown deprecated command %q", commandName)
+	}
+
+	cmd.SetArgs(nil)
+	require.NoError(t, cmd.Execute())
+}

--- a/cli/new.go
+++ b/cli/new.go
@@ -114,8 +114,9 @@ After Creation:
 
 			if t == "" {
 				if noTTY {
-					core.PrintError("New", fmt.Errorf("type is required when using --yes. Allowed: agent | mcp | sandbox | job | volumetemplate"))
-					return
+					err := fmt.Errorf("type is required when using --yes. Allowed: agent | mcp | sandbox | job | volumetemplate")
+					core.PrintError("New", err)
+					core.ExitWithError(err)
 				}
 				// Prompt for type using huh
 				var selected string
@@ -153,7 +154,9 @@ After Creation:
 			case newTypeVolumeTemplate:
 				core.RunVolumeTemplateCreation(dirArg, templateName, noTTY)
 			default:
-				core.PrintError("New", fmt.Errorf("unknown type '%s'. Allowed: agent | mcp | sandbox | job | volumetemplate", t))
+				err := fmt.Errorf("unknown type '%s'. Allowed: agent | mcp | sandbox | job | volumetemplate", t)
+				core.PrintError("New", err)
+				core.ExitWithError(err)
 			}
 		},
 	}

--- a/cli/new.go
+++ b/cli/new.go
@@ -174,6 +174,13 @@ After Creation:
   # Create MCP server with default template (non-interactive)
   bl new mcp my-mcp-server -y -t mcp-py
 
+  # Choose a sandbox type interactively
+  bl new sandbox
+
+  # Create Claude Code or Codex sandboxes non-interactively
+  bl new sandbox my-claude-sandbox -t claude-code -y
+  bl new sandbox my-codex-sandbox -t codex -y
+
   # Create job with specific template
   bl new job my-batch-job -t jobs-py
 

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	err := cli.Execute(version, commit, date)
 	if err != nil {
-		fmt.Println("Error", err)
+		fmt.Fprintln(os.Stderr, "Error", err)
 		core.ExitWithError(err)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds Scratch, Claude Code, and Codex options to the sandbox scaffold flow.
- Makes `bl new sandbox` and `bl new` -> Sandbox use the same sandbox type picker.
- Keeps noninteractive `-t/--template -y` usage working, including short aliases like `scratch`, `claude-code`, and `codex`.
- Generates Claude Code and Codex sandbox files that install `claude` or `codex` on PATH.

## Validation

- `go test ./...`
- `bl new sandbox` prompt flow
- `bl new` -> Sandbox prompt flow
- `bl new sandbox -t scratch -y`
- `bl new sandbox -t claude-code -y`
- `bl new sandbox -t codex -y`
- Invalid sandbox template output lists available options
- Docker runtime checks:
  - `claude --version` -> `2.1.139 (Claude Code)`
  - `codex --version` -> `codex-cli 0.130.0`

Linear: ENG-2237

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds Scratch, Claude Code, and Codex sandbox template choices to `bl new sandbox`. Introduces `sandbox_templates.go` with variant-aware file generation (Dockerfile, Makefile, entrypoint.sh, README), a curated `PromptSandboxTemplateOptions` picker, short-alias normalization for `-t` flag, client-side catalog augmentation via `ensureSandboxTemplates`, and symlink/directory guards on all runtime file writes via `os.OpenRoot`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 296d22d965003cd5fd21b2433c0bf9293ad41bba.</sup>
<!-- /MENDRAL_SUMMARY -->