### PR TITLE
[codex] Update sdk-go pagination handling

### DIFF
--- a/cli/commands_integration_test.go
+++ b/cli/commands_integration_test.go
@@ -46,6 +46,17 @@ func setupTestServer(t *testing.T, handlers map[string]http.HandlerFunc) *httpte
 	}))
 }
 
+func paginatedResponse(data interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"data": data,
+		"meta": map[string]interface{}{
+			"hasMore":    false,
+			"nextCursor": "",
+			"total":      0,
+		},
+	}
+}
+
 // setupTestClient creates and sets a mock blaxel client
 func setupTestClient(t *testing.T, serverURL string) {
 	t.Setenv("BL_API_KEY", "test-api-key")
@@ -81,7 +92,7 @@ func TestListAgentsIntegration(t *testing.T) {
 				},
 			}
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(agents)
+			_ = json.NewEncoder(w).Encode(paginatedResponse(agents))
 		},
 	}
 
@@ -91,7 +102,7 @@ func TestListAgentsIntegration(t *testing.T) {
 
 	ctx := context.Background()
 	client := core.GetClient()
-	agents, err := client.Agents.List(ctx)
+	agents, err := core.ListAllAgents(ctx, client)
 	require.NoError(t, err)
 	assert.Len(t, *agents, 2)
 }
@@ -110,7 +121,7 @@ func TestListFunctionsIntegration(t *testing.T) {
 				},
 			}
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(functions)
+			_ = json.NewEncoder(w).Encode(paginatedResponse(functions))
 		},
 	}
 
@@ -120,7 +131,7 @@ func TestListFunctionsIntegration(t *testing.T) {
 
 	ctx := context.Background()
 	client := core.GetClient()
-	functions, err := client.Functions.List(ctx)
+	functions, err := core.ListAllFunctions(ctx, client)
 	require.NoError(t, err)
 	assert.Len(t, *functions, 1)
 }
@@ -150,7 +161,7 @@ func TestListModelsIntegration(t *testing.T) {
 				},
 			}
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(models)
+			_ = json.NewEncoder(w).Encode(paginatedResponse(models))
 		},
 	}
 
@@ -160,7 +171,7 @@ func TestListModelsIntegration(t *testing.T) {
 
 	ctx := context.Background()
 	client := core.GetClient()
-	models, err := client.Models.List(ctx)
+	models, err := core.ListAllModels(ctx, client)
 	require.NoError(t, err)
 	assert.Len(t, *models, 2)
 }
@@ -179,7 +190,7 @@ func TestListJobsIntegration(t *testing.T) {
 				},
 			}
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(jobs)
+			_ = json.NewEncoder(w).Encode(paginatedResponse(jobs))
 		},
 	}
 
@@ -189,7 +200,7 @@ func TestListJobsIntegration(t *testing.T) {
 
 	ctx := context.Background()
 	client := core.GetClient()
-	jobs, err := client.Jobs.List(ctx)
+	jobs, err := core.ListAllJobs(ctx, client)
 	require.NoError(t, err)
 	assert.Len(t, *jobs, 1)
 }
@@ -208,7 +219,7 @@ func TestListSandboxesIntegration(t *testing.T) {
 				},
 			}
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(sandboxes)
+			_ = json.NewEncoder(w).Encode(paginatedResponse(sandboxes))
 		},
 	}
 
@@ -218,7 +229,7 @@ func TestListSandboxesIntegration(t *testing.T) {
 
 	ctx := context.Background()
 	client := core.GetClient()
-	sandboxes, err := client.Sandboxes.List(ctx)
+	sandboxes, err := core.ListAllSandboxes(ctx, client)
 	require.NoError(t, err)
 	assert.Len(t, *sandboxes, 1)
 }
@@ -239,7 +250,7 @@ func TestListVolumesIntegration(t *testing.T) {
 				},
 			}
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(volumes)
+			_ = json.NewEncoder(w).Encode(paginatedResponse(volumes))
 		},
 	}
 
@@ -249,7 +260,7 @@ func TestListVolumesIntegration(t *testing.T) {
 
 	ctx := context.Background()
 	client := core.GetClient()
-	volumes, err := client.Volumes.List(ctx)
+	volumes, err := core.ListAllVolumes(ctx, client)
 	require.NoError(t, err)
 	assert.Len(t, *volumes, 1)
 }
@@ -267,7 +278,7 @@ func TestListPoliciesIntegration(t *testing.T) {
 				},
 			}
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(policies)
+			_ = json.NewEncoder(w).Encode(paginatedResponse(policies))
 		},
 	}
 
@@ -277,7 +288,7 @@ func TestListPoliciesIntegration(t *testing.T) {
 
 	ctx := context.Background()
 	client := core.GetClient()
-	policies, err := client.Policies.List(ctx)
+	policies, err := core.ListAllPolicies(ctx, client)
 	require.NoError(t, err)
 	assert.Len(t, *policies, 1)
 }
@@ -469,7 +480,7 @@ func TestJobExecutionsListIntegration(t *testing.T) {
 				},
 			}
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(executions)
+			_ = json.NewEncoder(w).Encode(paginatedResponse(executions))
 		},
 	}
 
@@ -479,7 +490,7 @@ func TestJobExecutionsListIntegration(t *testing.T) {
 
 	ctx := context.Background()
 	client := core.GetClient()
-	executions, err := client.Jobs.Executions.List(ctx, "my-job", blaxel.JobExecutionListParams{})
+	executions, err := core.ListAllJobExecutions(ctx, client, "my-job")
 	require.NoError(t, err)
 	assert.Len(t, *executions, 2)
 }
@@ -571,7 +582,7 @@ func TestAPIErrorHandlingIntegration(t *testing.T) {
 
 			ctx := context.Background()
 			client := core.GetClient()
-			_, err := client.Agents.List(ctx)
+			_, err := core.ListAllAgents(ctx, client)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.expected)
 		})

--- a/cli/completions.go
+++ b/cli/completions.go
@@ -10,6 +10,7 @@ import (
 
 	blaxel "github.com/blaxel-ai/sdk-go"
 	"github.com/blaxel-ai/sdk-go/option"
+	"github.com/blaxel-ai/toolkit/cli/core"
 	"github.com/spf13/cobra"
 )
 
@@ -113,7 +114,6 @@ var sandboxPreviewKeywords = []string{"previews", "preview", "pv"}
 // previewTokenKeywords are the keywords that indicate token nested resources for previews
 var previewTokenKeywords = []string{"tokens", "token", "pvt"}
 
-
 // CompleteSandboxNames returns a list of sandbox names for shell completion
 func CompleteSandboxNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	ctx, cancel := completionContext()
@@ -123,7 +123,7 @@ func CompleteSandboxNames(cmd *cobra.Command, args []string, toComplete string) 
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	sandboxes, err := client.Sandboxes.List(ctx)
+	sandboxes, err := core.ListAllSandboxes(ctx, client)
 	if err != nil || sandboxes == nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -338,7 +338,7 @@ func CompleteJobNames(cmd *cobra.Command, args []string, toComplete string) ([]s
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	jobs, err := client.Jobs.List(ctx)
+	jobs, err := core.ListAllJobs(ctx, client)
 	if err != nil || jobs == nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -403,7 +403,7 @@ func CompleteJobExecutionIDs(jobName string, toComplete string) ([]string, cobra
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	executions, err := client.Jobs.Executions.List(ctx, jobName, blaxel.JobExecutionListParams{})
+	executions, err := core.ListAllJobExecutions(ctx, client, jobName)
 	if err != nil || executions == nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -553,7 +553,7 @@ func CompleteAgentNames(cmd *cobra.Command, args []string, toComplete string) ([
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	agents, err := client.Agents.List(ctx)
+	agents, err := core.ListAllAgents(ctx, client)
 	if err != nil || agents == nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -618,7 +618,7 @@ func CompleteFunctionNames(cmd *cobra.Command, args []string, toComplete string)
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	functions, err := client.Functions.List(ctx)
+	functions, err := core.ListAllFunctions(ctx, client)
 	if err != nil || functions == nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -683,7 +683,7 @@ func CompleteModelNames(cmd *cobra.Command, args []string, toComplete string) ([
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	models, err := client.Models.List(ctx)
+	models, err := core.ListAllModels(ctx, client)
 	if err != nil || models == nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -748,7 +748,7 @@ func CompleteVolumeNames(cmd *cobra.Command, args []string, toComplete string) (
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	volumes, err := client.Volumes.List(ctx)
+	volumes, err := core.ListAllVolumes(ctx, client)
 	if err != nil || volumes == nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -810,7 +810,7 @@ func CompletePolicyNames(cmd *cobra.Command, args []string, toComplete string) (
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	policies, err := client.Policies.List(ctx)
+	policies, err := core.ListAllPolicies(ctx, client)
 	if err != nil || policies == nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/cli/connect.go
+++ b/cli/connect.go
@@ -101,7 +101,7 @@ Examples:
 					core.PrintError("Connect", err)
 
 					// List available sandboxes
-					sandboxes, listErr := client.Sandboxes.List(ctx)
+					sandboxes, listErr := core.ListAllSandboxes(ctx, client)
 					if listErr == nil && sandboxes != nil && len(*sandboxes) > 0 {
 						names := make([]string, 0, len(*sandboxes))
 						for _, sb := range *sandboxes {

--- a/cli/core/list_all.go
+++ b/cli/core/list_all.go
@@ -1,0 +1,161 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	blaxel "github.com/blaxel-ai/sdk-go"
+)
+
+const listAllPageLimit int64 = 200
+
+func listAllPages[T any](fetch func(cursor string) ([]T, bool, string, error)) (*[]T, error) {
+	var all []T
+	cursor := ""
+	seenCursors := map[string]struct{}{}
+
+	for {
+		data, hasMore, nextCursor, err := fetch(cursor)
+		if err != nil {
+			return nil, err
+		}
+
+		all = append(all, data...)
+
+		if !hasMore || nextCursor == "" {
+			return &all, nil
+		}
+
+		if _, seen := seenCursors[nextCursor]; seen {
+			return nil, fmt.Errorf("pagination cursor loop detected")
+		}
+		seenCursors[nextCursor] = struct{}{}
+		cursor = nextCursor
+	}
+}
+
+func ListAllAgents(ctx context.Context, c *blaxel.Client) (*[]blaxel.Agent, error) {
+	return listAllPages(func(cursor string) ([]blaxel.Agent, bool, string, error) {
+		params := blaxel.AgentListParams{Limit: blaxel.Int(listAllPageLimit)}
+		if cursor != "" {
+			params.Cursor = blaxel.String(cursor)
+		}
+		page, err := c.Agents.List(ctx, params)
+		if err != nil || page == nil {
+			return nil, false, "", err
+		}
+		return page.Data, page.Meta.HasMore, page.Meta.NextCursor, nil
+	})
+}
+
+func ListAllPolicies(ctx context.Context, c *blaxel.Client) (*[]blaxel.Policy, error) {
+	return listAllPages(func(cursor string) ([]blaxel.Policy, bool, string, error) {
+		params := blaxel.PolicyListParams{Limit: blaxel.Int(listAllPageLimit)}
+		if cursor != "" {
+			params.Cursor = blaxel.String(cursor)
+		}
+		page, err := c.Policies.List(ctx, params)
+		if err != nil || page == nil {
+			return nil, false, "", err
+		}
+		return page.Data, page.Meta.HasMore, page.Meta.NextCursor, nil
+	})
+}
+
+func ListAllModels(ctx context.Context, c *blaxel.Client) (*[]blaxel.Model, error) {
+	return listAllPages(func(cursor string) ([]blaxel.Model, bool, string, error) {
+		params := blaxel.ModelListParams{Limit: blaxel.Int(listAllPageLimit)}
+		if cursor != "" {
+			params.Cursor = blaxel.String(cursor)
+		}
+		page, err := c.Models.List(ctx, params)
+		if err != nil || page == nil {
+			return nil, false, "", err
+		}
+		return page.Data, page.Meta.HasMore, page.Meta.NextCursor, nil
+	})
+}
+
+func ListAllFunctions(ctx context.Context, c *blaxel.Client) (*[]blaxel.Function, error) {
+	return listAllPages(func(cursor string) ([]blaxel.Function, bool, string, error) {
+		params := blaxel.FunctionListParams{Limit: blaxel.Int(listAllPageLimit)}
+		if cursor != "" {
+			params.Cursor = blaxel.String(cursor)
+		}
+		page, err := c.Functions.List(ctx, params)
+		if err != nil || page == nil {
+			return nil, false, "", err
+		}
+		return page.Data, page.Meta.HasMore, page.Meta.NextCursor, nil
+	})
+}
+
+func ListAllSandboxes(ctx context.Context, c *blaxel.Client) (*[]blaxel.Sandbox, error) {
+	return listAllPages(func(cursor string) ([]blaxel.Sandbox, bool, string, error) {
+		params := blaxel.SandboxListParams{Limit: blaxel.Int(listAllPageLimit)}
+		if cursor != "" {
+			params.Cursor = blaxel.String(cursor)
+		}
+		page, err := c.Sandboxes.List(ctx, params)
+		if err != nil || page == nil {
+			return nil, false, "", err
+		}
+		return page.Data, page.Meta.HasMore, page.Meta.NextCursor, nil
+	})
+}
+
+func ListAllJobs(ctx context.Context, c *blaxel.Client) (*[]blaxel.Job, error) {
+	return listAllPages(func(cursor string) ([]blaxel.Job, bool, string, error) {
+		params := blaxel.JobListParams{Limit: blaxel.Int(listAllPageLimit)}
+		if cursor != "" {
+			params.Cursor = blaxel.String(cursor)
+		}
+		page, err := c.Jobs.List(ctx, params)
+		if err != nil || page == nil {
+			return nil, false, "", err
+		}
+		return page.Data, page.Meta.HasMore, page.Meta.NextCursor, nil
+	})
+}
+
+func ListAllVolumes(ctx context.Context, c *blaxel.Client) (*[]blaxel.VolumeListResponseData, error) {
+	return listAllPages(func(cursor string) ([]blaxel.VolumeListResponseData, bool, string, error) {
+		params := blaxel.VolumeListParams{Limit: blaxel.Int(listAllPageLimit)}
+		if cursor != "" {
+			params.Cursor = blaxel.String(cursor)
+		}
+		page, err := c.Volumes.List(ctx, params)
+		if err != nil || page == nil {
+			return nil, false, "", err
+		}
+		return page.Data, page.Meta.HasMore, page.Meta.NextCursor, nil
+	})
+}
+
+func ListAllDrives(ctx context.Context, c *blaxel.Client) (*[]blaxel.DriveListResponseData, error) {
+	return listAllPages(func(cursor string) ([]blaxel.DriveListResponseData, bool, string, error) {
+		params := blaxel.DriveListParams{Limit: blaxel.Int(listAllPageLimit)}
+		if cursor != "" {
+			params.Cursor = blaxel.String(cursor)
+		}
+		page, err := c.Drives.List(ctx, params)
+		if err != nil || page == nil {
+			return nil, false, "", err
+		}
+		return page.Data, page.Meta.HasMore, page.Meta.NextCursor, nil
+	})
+}
+
+func ListAllJobExecutions(ctx context.Context, c *blaxel.Client, jobName string) (*[]blaxel.JobExecution, error) {
+	return listAllPages(func(cursor string) ([]blaxel.JobExecution, bool, string, error) {
+		params := blaxel.JobExecutionListParams{Limit: blaxel.Int(listAllPageLimit)}
+		if cursor != "" {
+			params.Cursor = blaxel.String(cursor)
+		}
+		page, err := c.Jobs.Executions.List(ctx, jobName, params)
+		if err != nil || page == nil {
+			return nil, false, "", err
+		}
+		return page.Data, page.Meta.HasMore, page.Meta.NextCursor, nil
+	})
+}

--- a/cli/core/list_all_test.go
+++ b/cli/core/list_all_test.go
@@ -1,0 +1,69 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	blaxel "github.com/blaxel-ai/sdk-go"
+	"github.com/blaxel-ai/sdk-go/option"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListAllAgentsFetchesEveryPage(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/agents", r.URL.Path)
+		require.Equal(t, "200", r.URL.Query().Get("limit"))
+
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+
+		switch requests {
+		case 1:
+			assert.Empty(t, r.URL.Query().Get("cursor"))
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": []map[string]interface{}{
+					{"metadata": map[string]interface{}{"name": "agent-1"}},
+				},
+				"meta": map[string]interface{}{
+					"hasMore":    true,
+					"nextCursor": "cursor-2",
+					"total":      2,
+				},
+			})
+		case 2:
+			assert.Equal(t, "cursor-2", r.URL.Query().Get("cursor"))
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": []map[string]interface{}{
+					{"metadata": map[string]interface{}{"name": "agent-2"}},
+				},
+				"meta": map[string]interface{}{
+					"hasMore":    false,
+					"nextCursor": "",
+					"total":      2,
+				},
+			})
+		default:
+			t.Fatalf("unexpected request %d", requests)
+		}
+	}))
+	defer server.Close()
+
+	client, err := blaxel.NewDefaultClient(
+		option.WithBaseURL(server.URL),
+		option.WithWorkspace("test-workspace"),
+		option.WithAPIKey("test-api-key"),
+	)
+	require.NoError(t, err)
+
+	agents, err := ListAllAgents(context.Background(), &client)
+	require.NoError(t, err)
+	require.Len(t, *agents, 2)
+	assert.Equal(t, "agent-1", (*agents)[0].Metadata.Name)
+	assert.Equal(t, "agent-2", (*agents)[1].Metadata.Name)
+	assert.Equal(t, 2, requests)
+}

--- a/cli/core/operations.go
+++ b/cli/core/operations.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"context"
+
+	blaxel "github.com/blaxel-ai/sdk-go"
 )
 
 // RegisterResourceOperations registers the SDK client methods for each resource
@@ -16,25 +18,33 @@ func RegisterResourceOperations(ctx context.Context) {
 	for _, resource := range resources {
 		switch resource.Kind {
 		case "Agent":
-			resource.List = c.Agents.List
+			resource.List = func(ctx context.Context) (*[]blaxel.Agent, error) {
+				return ListAllAgents(ctx, c)
+			}
 			resource.Get = c.Agents.Get
 			resource.Delete = c.Agents.Delete
 			resource.Put = c.Agents.Update
 			resource.Post = c.Agents.New
 		case "Policy":
-			resource.List = c.Policies.List
+			resource.List = func(ctx context.Context) (*[]blaxel.Policy, error) {
+				return ListAllPolicies(ctx, c)
+			}
 			resource.Get = c.Policies.Get
 			resource.Delete = c.Policies.Delete
 			resource.Put = c.Policies.Update
 			resource.Post = c.Policies.New
 		case "Model":
-			resource.List = c.Models.List
+			resource.List = func(ctx context.Context) (*[]blaxel.Model, error) {
+				return ListAllModels(ctx, c)
+			}
 			resource.Get = c.Models.Get
 			resource.Delete = c.Models.Delete
 			resource.Put = c.Models.Update
 			resource.Post = c.Models.New
 		case "Function":
-			resource.List = c.Functions.List
+			resource.List = func(ctx context.Context) (*[]blaxel.Function, error) {
+				return ListAllFunctions(ctx, c)
+			}
 			resource.Get = c.Functions.Get
 			resource.Delete = c.Functions.Delete
 			resource.Put = c.Functions.Update
@@ -46,19 +56,25 @@ func RegisterResourceOperations(ctx context.Context) {
 			resource.Put = c.Integrations.Connections.Update
 			resource.Post = c.Integrations.Connections.New
 		case "Sandbox":
-			resource.List = c.Sandboxes.List
+			resource.List = func(ctx context.Context) (*[]blaxel.Sandbox, error) {
+				return ListAllSandboxes(ctx, c)
+			}
 			resource.Get = c.Sandboxes.Get
 			resource.Delete = c.Sandboxes.Delete
 			resource.Put = c.Sandboxes.Update
 			resource.Post = c.Sandboxes.New
 		case "Job":
-			resource.List = c.Jobs.List
+			resource.List = func(ctx context.Context) (*[]blaxel.Job, error) {
+				return ListAllJobs(ctx, c)
+			}
 			resource.Get = c.Jobs.Get
 			resource.Delete = c.Jobs.Delete
 			resource.Put = c.Jobs.Update
 			resource.Post = c.Jobs.New
 		case "Volume":
-			resource.List = c.Volumes.List
+			resource.List = func(ctx context.Context) (*[]blaxel.VolumeListResponseData, error) {
+				return ListAllVolumes(ctx, c)
+			}
 			resource.Get = c.Volumes.Get
 			resource.Delete = c.Volumes.Delete
 			resource.Put = c.Volumes.Update
@@ -75,7 +91,9 @@ func RegisterResourceOperations(ctx context.Context) {
 			resource.Delete = c.Images.Delete
 			// Images don't have Put/Post operations
 		case "Drive":
-			resource.List = c.Drives.List
+			resource.List = func(ctx context.Context) (*[]blaxel.DriveListResponseData, error) {
+				return ListAllDrives(ctx, c)
+			}
 			resource.Get = c.Drives.Get
 			resource.Delete = c.Drives.Delete
 			resource.Put = c.Drives.Update

--- a/cli/get_job_executions.go
+++ b/cli/get_job_executions.go
@@ -43,7 +43,7 @@ func listJobExecutions(jobName string) {
 	ctx := context.Background()
 	client := core.GetClient()
 
-	executions, err := client.Jobs.Executions.List(ctx, jobName, blaxel.JobExecutionListParams{})
+	executions, err := core.ListAllJobExecutions(ctx, client, jobName)
 	if err != nil {
 		core.PrintError("Get", fmt.Errorf("failed to list job executions: %w", err))
 		os.Exit(1)

--- a/cli/token.go
+++ b/cli/token.go
@@ -67,7 +67,7 @@ export TOKEN=$(bl token)
 
 			// Get workspace to check if access is allowed + it refreshes the token if needed
 			client := core.GetClient()
-			_, err := client.Workspaces.Get(context.Background(), workspace)
+			_, err := client.Workspaces.Get(context.Background(), workspace, blaxel.WorkspaceGetParams{})
 			if err != nil {
 				err := fmt.Errorf("failed to get workspace '%s': %w", workspace, err)
 				core.PrintError("token", err)

--- a/cli/workspace.go
+++ b/cli/workspace.go
@@ -123,7 +123,7 @@ func CheckWorkspaceAccess(workspaceName string, credentials blaxel.Credentials) 
 	}
 
 	c := blaxel.NewClient(opts...)
-	workspace, err := c.Workspaces.Get(context.Background(), workspaceName)
+	workspace, err := c.Workspaces.Get(context.Background(), workspaceName, blaxel.WorkspaceGetParams{})
 	if err != nil {
 		return blaxel.Workspace{}, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/atotto/clipboard v0.1.4
-	github.com/blaxel-ai/sdk-go v0.18.0
+	github.com/blaxel-ai/sdk-go v0.21.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3v
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/blaxel-ai/sdk-go v0.18.0 h1:3dEgyfxCnowHHlirjnxP5GCAg6sbGl+PfLnIttMBWfE=
-github.com/blaxel-ai/sdk-go v0.18.0/go.mod h1:qnHmO29t6qLcjsbVE8EMdSe/zp96Le3lppNA0pr7k0k=
+github.com/blaxel-ai/sdk-go v0.21.0 h1:sh0X8SUkhmm1uX3jWksZCOiX+r1Ou7oRoTLRkD1MPeQ=
+github.com/blaxel-ai/sdk-go v0.21.0/go.mod h1:qnHmO29t6qLcjsbVE8EMdSe/zp96Le3lppNA0pr7k0k=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/test/config_test.go
+++ b/test/config_test.go
@@ -645,10 +645,9 @@ func TestConfigToFunctionConversion(t *testing.T) {
 func TestConfigToJobConversion(t *testing.T) {
 	// Simulate what GenerateDeployment does for job type
 	runtime := map[string]interface{}{
-		"memory":             int64(4096),
-		"maxConcurrentTasks": int64(10),
-		"timeout":            int64(900),
-		"maxRetries":         int64(3),
+		"memory":     int64(4096),
+		"timeout":    int64(900),
+		"maxRetries": int64(3),
 		"envs": []core.Env{
 			{Name: "BATCH_SIZE", Value: "100"},
 		},
@@ -690,7 +689,6 @@ func TestConfigToJobConversion(t *testing.T) {
 
 	// Verify runtime
 	assert.Equal(t, int64(4096), jobParam.Spec.Runtime.Memory.Value)
-	assert.Equal(t, int64(10), jobParam.Spec.Runtime.MaxConcurrentTasks.Value)
 	assert.Equal(t, int64(900), jobParam.Spec.Runtime.Timeout.Value)
 	assert.Equal(t, int64(3), jobParam.Spec.Runtime.MaxRetries.Value)
 

--- a/test/job_executions_test.go
+++ b/test/job_executions_test.go
@@ -54,7 +54,7 @@ func TestJobExecutions(t *testing.T) {
 			t.Errorf("Failed to list executions: %v", err)
 			return
 		}
-		t.Logf("Found %d executions", len(*executions))
+		t.Logf("Found %d executions", len(executions.Data))
 	})
 
 	// Test creating an execution


### PR DESCRIPTION
## Summary
- Update `github.com/blaxel-ai/sdk-go` to `v0.21.0`.
- Keep CLI list behavior unchanged by fetching all cursor-paginated pages internally.
- Update completions, nested job execution listing, and tests for the new `{data, meta}` response shape.

## Validation
- `go test ./...`
- `make build-dev`
- `~/.local/bin/bl version`

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Updates `sdk-go` from v0.18.0 to v0.21.0, adapting the CLI to the new cursor-paginated `{data, meta}` response shape. Introduces a generic `listAllPages` helper that transparently fetches all pages, with cursor loop detection, and replaces all direct `.List()` calls across completions, commands, and operations.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4d3063ff195bf50b4c6f5857998928505bf2e9cb.</sup>
<!-- /MENDRAL_SUMMARY -->