### PR TITLE
fix: use sandbox picker for sandbox creation

### DIFF
--- a/cli/core/create.go
+++ b/cli/core/create.go
@@ -465,7 +465,7 @@ func RunSandboxCreation(dirArg string, templateName string, noTTY bool) {
 			SpinnerTitle: "Creating your blaxel sandbox...",
 		},
 		func(directory string, templates Templates) TemplateOptions {
-			return PromptTemplateOptions(directory, templates, "sandbox", false, 5)
+			return PromptSandboxTemplateOptions(directory, templates)
 		},
 		func(opts TemplateOptions) {
 			PrintSuccess("Your blaxel sandbox has been created successfully!")


### PR DESCRIPTION
- Routes `bl new sandbox` through the Scratch / Claude Code / Codex picker.
- Keeps non-interactive sandbox template usage working.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Replaces the generic `PromptTemplateOptions` call in `RunSandboxCreation` with a new `PromptSandboxTemplateOptions` function that surfaces the Scratch / Claude Code / Codex picker specifically for sandbox creation.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit febe83e9de145b1c9c5663e49bb3eca39cb16ade.</sup>
<!-- /MENDRAL_SUMMARY -->