### PR TITLE
ENG-1725 Fix installer PATH detection for commented entries

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -329,6 +329,22 @@ prompt_user() {
   return 0
 }
 
+# Check if the RC file already contains an active PATH entry for the install dir
+rc_file_has_active_path_entry() {
+  local rc_file_path="$1"
+  local shell_name="$2"
+  local bin_path="$3"
+
+  [ -f "$rc_file_path" ] || return 1
+
+  awk -v shell_name="$shell_name" -v bin_path="$bin_path" '
+    /^[[:space:]]*#/ { next }
+    shell_name == "fish" && /^[[:space:]]*set[[:space:]]+-gx[[:space:]]+PATH[[:space:]]+/ && index($0, bin_path) > 0 { found = 1 }
+    shell_name != "fish" && /^[[:space:]]*(export[[:space:]]+)?PATH=/ && index($0, bin_path) > 0 { found = 1 }
+    END { exit found ? 0 : 1 }
+  ' "$rc_file_path"
+}
+
 # --- Installer setup functions ---
 
 # Function to detect shell and provide PATH instructions
@@ -364,7 +380,7 @@ setup_path_interactive() {
   echo ""
 
   # Check if PATH is already configured
-  if [ -f "$rc_file_path" ] && grep -q "# Added by ${BINARY} installer" "$rc_file_path"; then
+  if rc_file_has_active_path_entry "$rc_file_path" "$shell_name" "$bin_path"; then
     echo "${BINARY} is already configured in your PATH via $rc_file"
     echo ""
     echo "To get started, run: ${BINARY_SHORT_NAME} --help"

--- a/test/install/test_install.sh
+++ b/test/install/test_install.sh
@@ -27,7 +27,13 @@ export BL_INSTALL_COMPLETION=true
 export BL_INSTALL_TRACKING=true
 
 echo "=== Installing with SHELL=bash ==="
+printf '# Added by blaxel installer\n#export PATH="%s:$PATH"\n' "$HOME/.local/bin" > "$HOME/.bashrc"
 SHELL=/bin/bash sh /home/testuser/install.sh
+if grep -Eq "^[[:space:]]*export[[:space:]]+PATH=.*$HOME/.local/bin" "$HOME/.bashrc"; then
+  pass "bash: commented PATH entry is ignored and active PATH export is added"
+else
+  fail "bash: installer treated commented PATH entry as active"
+fi
 
 echo ""
 echo "=== Adding bl to PATH for subsequent installs ==="


### PR DESCRIPTION
## Summary
- Ignore commented PATH lines when checking if the installer already configured the shell rc file.
- Add an install test for the `.bashrc` case from ENG-1725.

## Root cause
The installer only checked for the `# Added by blaxel installer` marker, so a disabled line like `#export PATH=...` was treated as active configuration.

## Validation
- `sh -n install.sh`
- `bash -n test/install/test_install.sh`
- `git diff --check HEAD~1 HEAD`
- `make test-install`
- `make build-dev`

Linear: ENG-1725

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes installer PATH detection by replacing a comment-marker grep with an `awk`-based function that skips commented lines and looks for an actual active PATH export. Adds a test that pre-seeds `.bashrc` with a commented PATH entry to verify the installer correctly adds an active entry.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 7f74746edecb1d1fcd67a7fee42bba0c712b0f94.</sup>
<!-- /MENDRAL_SUMMARY -->