### PR TITLE
Validate explicit workspace during login

### DIFF
--- a/cli/auth/device.go
+++ b/cli/auth/device.go
@@ -248,16 +248,18 @@ func deviceModeLoginFinalize(deviceCode string, workspace string, retries int) {
 
 	err = validateWorkspace(workspace, creds)
 	if err != nil {
-		core.PrintError("Login", fmt.Errorf("error accessing workspace %s : %w", workspace, err))
-	} else {
-		if err := blaxel.SaveCredentials(workspace, creds); err != nil {
-			core.PrintError("Login", fmt.Errorf("failed to save credentials: %w", err))
-			core.ExitWithError(err)
-		}
-		if err := blaxel.SetCurrentWorkspace(workspace); err != nil {
-			core.PrintError("Login", fmt.Errorf("failed to set workspace: %w", err))
-			core.ExitWithError(err)
-		}
-		core.PrintSuccess(fmt.Sprintf("Successfully logged in to workspace %s", workspace))
+		err = fmt.Errorf("error accessing workspace %s : %w", workspace, err)
+		core.PrintError("Login", err)
+		core.ExitWithError(err)
 	}
+
+	if err := blaxel.SaveCredentials(workspace, creds); err != nil {
+		core.PrintError("Login", fmt.Errorf("failed to save credentials: %w", err))
+		core.ExitWithError(err)
+	}
+	if err := blaxel.SetCurrentWorkspace(workspace); err != nil {
+		core.PrintError("Login", fmt.Errorf("failed to set workspace: %w", err))
+		core.ExitWithError(err)
+	}
+	core.PrintSuccess(fmt.Sprintf("Successfully logged in to workspace %s", workspace))
 }

--- a/cli/auth/utils.go
+++ b/cli/auth/utils.go
@@ -8,16 +8,17 @@ import (
 	"github.com/blaxel-ai/sdk-go/option"
 )
 
-// WorkspaceLister interface for listing workspaces (allows mocking)
-type WorkspaceLister interface {
+// WorkspaceClient interface for workspace lookups (allows mocking)
+type WorkspaceClient interface {
+	Get(ctx context.Context, workspaceName string, opts ...option.RequestOption) (*blaxel.Workspace, error)
 	List(ctx context.Context, opts ...option.RequestOption) (*[]blaxel.Workspace, error)
 }
 
 // ClientFactory creates clients for workspace operations
-type ClientFactory func(opts ...option.RequestOption) WorkspaceLister
+type ClientFactory func(opts ...option.RequestOption) WorkspaceClient
 
 // defaultClientFactory creates the real blaxel client
-var defaultClientFactory ClientFactory = func(opts ...option.RequestOption) WorkspaceLister {
+var defaultClientFactory ClientFactory = func(opts ...option.RequestOption) WorkspaceClient {
 	client := blaxel.NewClient(opts...)
 	return &client.Workspaces
 }
@@ -29,7 +30,7 @@ func SetClientFactory(factory ClientFactory) {
 
 // ResetClientFactory resets to the default client factory
 func ResetClientFactory() {
-	defaultClientFactory = func(opts ...option.RequestOption) WorkspaceLister {
+	defaultClientFactory = func(opts ...option.RequestOption) WorkspaceClient {
 		client := blaxel.NewClient(opts...)
 		return &client.Workspaces
 	}
@@ -66,7 +67,17 @@ func validateWorkspaceWithFactory(workspace string, credentials blaxel.Credentia
 	opts := BuildClientOptions(workspace, credentials)
 	client := factory(opts...)
 
-	// Try to make a simple API call to validate
+	// If a workspace was provided, validate that exact workspace instead of only
+	// validating the credentials. This catches typos during `bl login <workspace>`
+	// before the workspace is persisted as the current context.
+	if workspace != "" {
+		if _, err := client.Get(context.Background(), workspace); err != nil {
+			return fmt.Errorf("workspace %q does not exist or is not accessible: %w", workspace, err)
+		}
+		return nil
+	}
+
+	// No explicit workspace: just verify the credentials can list accessible workspaces.
 	_, err := client.List(context.Background())
 	if err != nil {
 		return fmt.Errorf("failed to validate workspace credentials: %w", err)

--- a/cli/auth/utils_integration_test.go
+++ b/cli/auth/utils_integration_test.go
@@ -11,20 +11,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// mockWorkspaceLister implements WorkspaceLister for testing
-type mockWorkspaceLister struct {
+// mockWorkspaceClient implements WorkspaceClient for testing
+type mockWorkspaceClient struct {
 	workspaces *[]blaxel.Workspace
 	err        error
 }
 
-func (m *mockWorkspaceLister) List(ctx context.Context, opts ...option.RequestOption) (*[]blaxel.Workspace, error) {
+func (m *mockWorkspaceClient) Get(ctx context.Context, workspaceName string, opts ...option.RequestOption) (*blaxel.Workspace, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.workspaces == nil {
+		return nil, errors.New("workspace list unavailable")
+	}
+	for _, workspace := range *m.workspaces {
+		if workspace.Name == workspaceName {
+			return &workspace, nil
+		}
+	}
+	return nil, errors.New("workspace not found")
+}
+
+func (m *mockWorkspaceClient) List(ctx context.Context, opts ...option.RequestOption) (*[]blaxel.Workspace, error) {
 	return m.workspaces, m.err
 }
 
 // mockClientFactory creates a mock client factory for testing
 func mockClientFactory(workspaces *[]blaxel.Workspace, err error) ClientFactory {
-	return func(opts ...option.RequestOption) WorkspaceLister {
-		return &mockWorkspaceLister{workspaces: workspaces, err: err}
+	return func(opts ...option.RequestOption) WorkspaceClient {
+		return &mockWorkspaceClient{workspaces: workspaces, err: err}
 	}
 }
 
@@ -91,7 +106,17 @@ func TestValidateWorkspaceError(t *testing.T) {
 
 	err := validateWorkspaceWithFactory("test-workspace", blaxel.Credentials{APIKey: "key"}, factory)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to validate workspace credentials")
+	assert.Contains(t, err.Error(), "workspace \"test-workspace\" does not exist or is not accessible")
+}
+
+// TestValidateWorkspaceMissingWorkspace tests that an explicit workspace must exist.
+func TestValidateWorkspaceMissingWorkspace(t *testing.T) {
+	workspaces := []blaxel.Workspace{{Name: "other-workspace"}}
+	factory := mockClientFactory(&workspaces, nil)
+
+	err := validateWorkspaceWithFactory("test-workspace", blaxel.Credentials{APIKey: "key"}, factory)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "workspace \"test-workspace\" does not exist or is not accessible")
 }
 
 // TestValidateWorkspaceEmptyWorkspace tests validation with empty workspace
@@ -174,7 +199,7 @@ func TestListWorkspacesWithClientCredentials(t *testing.T) {
 
 // TestValidateWorkspaceWithAccessToken tests validation with access token
 func TestValidateWorkspaceWithAccessToken(t *testing.T) {
-	workspaces := []blaxel.Workspace{}
+	workspaces := []blaxel.Workspace{{Name: "ws"}}
 	factory := mockClientFactory(&workspaces, nil)
 
 	err := validateWorkspaceWithFactory("ws", blaxel.Credentials{AccessToken: "token"}, factory)
@@ -183,7 +208,7 @@ func TestValidateWorkspaceWithAccessToken(t *testing.T) {
 
 // TestValidateWorkspaceWithClientCredentials tests validation with client credentials
 func TestValidateWorkspaceWithClientCredentials(t *testing.T) {
-	workspaces := []blaxel.Workspace{}
+	workspaces := []blaxel.Workspace{{Name: "ws"}}
 	factory := mockClientFactory(&workspaces, nil)
 
 	err := validateWorkspaceWithFactory("ws", blaxel.Credentials{ClientCredentials: "creds"}, factory)
@@ -196,7 +221,7 @@ func TestSetAndResetClientFactory(t *testing.T) {
 	original := defaultClientFactory
 
 	// Set a mock factory
-	workspaces := []blaxel.Workspace{}
+	workspaces := []blaxel.Workspace{{Name: "test"}}
 	SetClientFactory(mockClientFactory(&workspaces, nil))
 
 	// Verify it's set (by calling the function which should work with mock)
@@ -222,7 +247,7 @@ func TestPublicFunctions(t *testing.T) {
 	SetClientFactory(mockClientFactory(&workspaces, nil))
 
 	// Test ValidateWorkspace
-	err := ValidateWorkspace("test", blaxel.Credentials{APIKey: "key"})
+	err := ValidateWorkspace("test-ws", blaxel.Credentials{APIKey: "key"})
 	require.NoError(t, err)
 
 	// Test ListWorkspaces
@@ -243,7 +268,7 @@ func TestLegacyFunctions(t *testing.T) {
 	SetClientFactory(mockClientFactory(&workspaces, nil))
 
 	// Test validateWorkspace (lowercase)
-	err := validateWorkspace("test", blaxel.Credentials{APIKey: "key"})
+	err := validateWorkspace("test-ws", blaxel.Credentials{APIKey: "key"})
 	require.NoError(t, err)
 
 	// Test listWorkspaces (lowercase)


### PR DESCRIPTION
## Summary
- Validate an explicit `bl login <workspace>` against that exact workspace before saving it.
- Fail device login on invalid explicit workspace instead of leaving a bad current workspace.

## Verification
- `go test ./...`
- `git diff --check -- cli/auth/device.go cli/auth/utils.go cli/auth/utils_integration_test.go`
