### PR TITLE
Normalize explicit workspace login errors

### DIFF
--- a/cli/auth/utils.go
+++ b/cli/auth/utils.go
@@ -72,7 +72,8 @@ func validateWorkspaceWithFactory(workspace string, credentials blaxel.Credentia
 	// before the workspace is persisted as the current context.
 	if workspace != "" {
 		if _, err := client.Get(context.Background(), workspace); err != nil {
-			return fmt.Errorf("workspace %q does not exist or is not accessible: %w", workspace, err)
+			// Use one message for every explicit workspace validation failure.
+			return fmt.Errorf("permission denied for workspace %q", workspace)
 		}
 		return nil
 	}

--- a/cli/auth/utils_integration_test.go
+++ b/cli/auth/utils_integration_test.go
@@ -106,17 +106,19 @@ func TestValidateWorkspaceError(t *testing.T) {
 
 	err := validateWorkspaceWithFactory("test-workspace", blaxel.Credentials{APIKey: "key"}, factory)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "workspace \"test-workspace\" does not exist or is not accessible")
+	assert.Equal(t, "permission denied for workspace \"test-workspace\"", err.Error())
+	assert.NotContains(t, err.Error(), "API error")
 }
 
-// TestValidateWorkspaceMissingWorkspace tests that an explicit workspace must exist.
+// TestValidateWorkspaceMissingWorkspace tests explicit workspace validation failure wording.
 func TestValidateWorkspaceMissingWorkspace(t *testing.T) {
 	workspaces := []blaxel.Workspace{{Name: "other-workspace"}}
 	factory := mockClientFactory(&workspaces, nil)
 
 	err := validateWorkspaceWithFactory("test-workspace", blaxel.Credentials{APIKey: "key"}, factory)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "workspace \"test-workspace\" does not exist or is not accessible")
+	assert.Equal(t, "permission denied for workspace \"test-workspace\"", err.Error())
+	assert.NotContains(t, err.Error(), "does not exist")
 }
 
 // TestValidateWorkspaceEmptyWorkspace tests validation with empty workspace


### PR DESCRIPTION
## Summary
- Return a consistent permission-denied message when explicit workspace validation fails during login.
- Keep underlying API errors out of the CLI error text.

## Verification
- `go test ./cli/auth`
- `go test ./...`
- `git diff --check -- cli/auth/utils.go cli/auth/utils_integration_test.go`
