### PR TITLE
Honor workspace flag during login

### DIFF
--- a/cli/auth/utils_integration_test.go
+++ b/cli/auth/utils_integration_test.go
@@ -43,6 +43,32 @@ func mockClientFactory(workspaces *[]blaxel.Workspace, err error) ClientFactory 
 	}
 }
 
+type countingWorkspaceClient struct {
+	getCalls         int
+	getWorkspaceName string
+	listCalls        int
+	workspace        *blaxel.Workspace
+	workspaces       *[]blaxel.Workspace
+	err              error
+}
+
+func (c *countingWorkspaceClient) Get(ctx context.Context, workspaceName string, opts ...option.RequestOption) (*blaxel.Workspace, error) {
+	c.getCalls++
+	c.getWorkspaceName = workspaceName
+	if c.err != nil {
+		return nil, c.err
+	}
+	if c.workspace == nil {
+		return nil, errors.New("workspace not found")
+	}
+	return c.workspace, nil
+}
+
+func (c *countingWorkspaceClient) List(ctx context.Context, opts ...option.RequestOption) (*[]blaxel.Workspace, error) {
+	c.listCalls++
+	return c.workspaces, c.err
+}
+
 // TestBuildClientOptionsEmpty tests BuildClientOptions with empty credentials
 func TestBuildClientOptionsEmpty(t *testing.T) {
 	opts := BuildClientOptions("", blaxel.Credentials{})
@@ -128,6 +154,36 @@ func TestValidateWorkspaceEmptyWorkspace(t *testing.T) {
 
 	err := validateWorkspaceWithFactory("", blaxel.Credentials{APIKey: "key"}, factory)
 	require.NoError(t, err)
+}
+
+func TestValidateWorkspaceExplicitWorkspaceUsesGet(t *testing.T) {
+	client := &countingWorkspaceClient{
+		workspace: &blaxel.Workspace{Name: "test-workspace"},
+	}
+	factory := func(opts ...option.RequestOption) WorkspaceClient {
+		return client
+	}
+
+	err := validateWorkspaceWithFactory("test-workspace", blaxel.Credentials{APIKey: "key"}, factory)
+	require.NoError(t, err)
+	assert.Equal(t, 1, client.getCalls)
+	assert.Equal(t, "test-workspace", client.getWorkspaceName)
+	assert.Equal(t, 0, client.listCalls)
+}
+
+func TestValidateWorkspaceEmptyWorkspaceUsesList(t *testing.T) {
+	workspaces := []blaxel.Workspace{{Name: "test-workspace"}}
+	client := &countingWorkspaceClient{
+		workspaces: &workspaces,
+	}
+	factory := func(opts ...option.RequestOption) WorkspaceClient {
+		return client
+	}
+
+	err := validateWorkspaceWithFactory("", blaxel.Credentials{APIKey: "key"}, factory)
+	require.NoError(t, err)
+	assert.Equal(t, 0, client.getCalls)
+	assert.Equal(t, 1, client.listCalls)
 }
 
 // TestListWorkspacesSuccess tests successful workspace listing

--- a/cli/login.go
+++ b/cli/login.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -61,15 +62,15 @@ bl login my-workspace
 After logging in, all commands will use this workspace by default.
 Override with --workspace flag: bl get agents --workspace other-workspace`,
 		Run: func(cmd *cobra.Command, args []string) {
-			workspace := "" // Default workspace
-			if len(args) > 0 {
-				if len(args) > 1 {
-					// Join all arguments and slugify so "My Workspace" -> "my-workspace"
-					workspaceJoined := core.Slugify(strings.Join(args, " "))
-					core.PrintWarning("Login failed: did you mean bl login " + workspaceJoined + " ?")
-					return
-				}
-				workspace = args[0]
+			workspace, workspaceSuggestion, err := resolveLoginWorkspace(cmd, args)
+			if workspaceSuggestion != "" {
+				core.PrintWarning("Login failed: did you mean bl login " + workspaceSuggestion + " ?")
+				return
+			}
+			if err != nil {
+				core.PrintError("Login", err)
+				core.ExitWithError(err)
+				return
 			}
 
 			if workspace == "" {
@@ -93,6 +94,40 @@ Override with --workspace flag: bl get agents --workspace other-workspace`,
 		},
 	}
 	return cmd
+}
+
+func resolveLoginWorkspace(cmd *cobra.Command, args []string) (string, string, error) {
+	if len(args) > 1 {
+		// Join all arguments and slugify so "My Workspace" -> "my-workspace".
+		return "", core.Slugify(strings.Join(args, " ")), nil
+	}
+
+	positionalWorkspace := ""
+	if len(args) == 1 {
+		positionalWorkspace = args[0]
+	}
+
+	flagWorkspace, flagChanged := explicitWorkspaceFlag(cmd)
+	if positionalWorkspace != "" {
+		if flagChanged && flagWorkspace != "" && flagWorkspace != positionalWorkspace {
+			return "", "", fmt.Errorf("workspace specified twice: positional workspace %q conflicts with --workspace %q", positionalWorkspace, flagWorkspace)
+		}
+		return positionalWorkspace, "", nil
+	}
+
+	if flagChanged {
+		return flagWorkspace, "", nil
+	}
+
+	return "", "", nil
+}
+
+func explicitWorkspaceFlag(cmd *cobra.Command) (string, bool) {
+	flag := cmd.Flag("workspace")
+	if flag == nil || !flag.Changed {
+		return "", false
+	}
+	return flag.Value.String(), true
 }
 
 func showLoginMenu(workspace string) {

--- a/cli/login_test.go
+++ b/cli/login_test.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"io"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveLoginWorkspace(t *testing.T) {
+	tests := []struct {
+		name               string
+		args               []string
+		expectedWorkspace  string
+		expectedSuggestion string
+		expectedErr        string
+	}{
+		{
+			name:              "positional workspace",
+			args:              []string{"login", "target-workspace"},
+			expectedWorkspace: "target-workspace",
+		},
+		{
+			name:              "inherited workspace flag after command",
+			args:              []string{"login", "--workspace", "target-workspace"},
+			expectedWorkspace: "target-workspace",
+		},
+		{
+			name:              "inherited workspace shorthand after command",
+			args:              []string{"login", "-w", "target-workspace"},
+			expectedWorkspace: "target-workspace",
+		},
+		{
+			name:              "inherited workspace flag before command",
+			args:              []string{"--workspace", "target-workspace", "login"},
+			expectedWorkspace: "target-workspace",
+		},
+		{
+			name:              "matching positional and flag workspace",
+			args:              []string{"login", "target-workspace", "--workspace", "target-workspace"},
+			expectedWorkspace: "target-workspace",
+		},
+		{
+			name:        "conflicting positional and flag workspace",
+			args:        []string{"login", "target-workspace", "--workspace", "other-workspace"},
+			expectedErr: `workspace specified twice: positional workspace "target-workspace" conflicts with --workspace "other-workspace"`,
+		},
+		{
+			name: "plain login keeps workspace picker behavior",
+			args: []string{"login"},
+		},
+		{
+			name:               "multi word positional suggestion",
+			args:               []string{"login", "My", "Workspace"},
+			expectedSuggestion: "my-workspace",
+		},
+		{
+			name: "unchanged flag default is ignored",
+			args: []string{"login"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workspace, suggestion, err := executeLoginWorkspaceResolver(t, tt.args)
+
+			assert.Equal(t, tt.expectedWorkspace, workspace)
+			assert.Equal(t, tt.expectedSuggestion, suggestion)
+			if tt.expectedErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tt.expectedErr, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func executeLoginWorkspaceResolver(t *testing.T, args []string) (string, string, error) {
+	t.Helper()
+
+	rootCmd := &cobra.Command{
+		Use:           "bl",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+	rootCmd.PersistentFlags().StringP("workspace", "w", "default-workspace", "Specify the workspace name")
+
+	var (
+		ran        bool
+		workspace  string
+		suggestion string
+		resolveErr error
+	)
+	loginCmd := &cobra.Command{
+		Use: "login [workspace]",
+		Run: func(cmd *cobra.Command, args []string) {
+			ran = true
+			workspace, suggestion, resolveErr = resolveLoginWorkspace(cmd, args)
+		},
+	}
+	rootCmd.AddCommand(loginCmd)
+	rootCmd.SetArgs(args)
+	rootCmd.SetOut(io.Discard)
+	rootCmd.SetErr(io.Discard)
+
+	require.NoError(t, rootCmd.Execute())
+	require.True(t, ran, "login command did not run")
+
+	return workspace, suggestion, resolveErr
+}


### PR DESCRIPTION
## Summary
- Treat explicit `--workspace` / `-w` on `bl login` as the login target.
- Fail fast when positional and flag workspace values conflict.
- Add regression coverage for login workspace resolution and exact validation dispatch.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Refactors login workspace resolution to honor the `--workspace`/`-w` flag as the login target, adds conflict detection when both positional and flag values are provided, and adds regression tests for the new resolution logic and validation dispatch path.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 19e02f2ffb05006727fdef71ff27eb3072f4a4ff.</sup>
<!-- /MENDRAL_SUMMARY -->