### PR TITLE
[codex] Support root bl --version

### DIFF
--- a/cli/core/root.go
+++ b/cli/core/root.go
@@ -376,6 +376,17 @@ func completeWorkspaceNames(cmd *cobra.Command, args []string, toComplete string
 }
 
 func Execute(releaseVersion string, releaseCommit string, releaseDate string) error {
+	if version == "" {
+		version = releaseVersion
+	}
+	if commit == "" {
+		commit = releaseCommit
+	}
+	if date == "" {
+		date = releaseDate
+	}
+	rootCmd.Version = version
+
 	// Prompt for tracking consent if not already configured
 	promptForTracking()
 
@@ -407,15 +418,6 @@ func Execute(releaseVersion string, releaseCommit string, releaseDate string) er
 	}
 	blaxel.InitializeEnvironment(workspace)
 
-	if version == "" {
-		version = releaseVersion
-	}
-	if commit == "" {
-		commit = releaseCommit
-	}
-	if date == "" {
-		date = releaseDate
-	}
 	SetSentryTag("version", version)
 	SetSentryTag("commit", commit)
 	SetSentryTag("workspace", workspace)
@@ -558,12 +560,8 @@ func promptForTracking() {
 		return
 	}
 
-	// Skip for completion and version commands
-	if len(os.Args) > 1 {
-		cmd := os.Args[1]
-		if cmd == "completion" || cmd == "__complete" || cmd == "version" {
-			return
-		}
+	if isTrackingPromptCommandExempt(os.Args) {
+		return
 	}
 
 	// Skip in CI environments
@@ -598,4 +596,13 @@ func promptForTracking() {
 		fmt.Println("✓ Tracking disabled.")
 	}
 	fmt.Println()
+}
+
+func isTrackingPromptCommandExempt(args []string) bool {
+	if len(args) <= 1 {
+		return false
+	}
+
+	cmd := args[1]
+	return cmd == "completion" || cmd == "__complete" || cmd == "version" || cmd == "--version"
 }

--- a/cli/core/root_test.go
+++ b/cli/core/root_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -282,6 +283,45 @@ func TestGetVerbose(t *testing.T) {
 
 	verbose = false
 	assert.False(t, GetVerbose())
+}
+
+func TestRootVersionFlagPreservesVerboseShorthand(t *testing.T) {
+	originalRootCmd := rootCmd
+	defer func() { rootCmd = originalRootCmd }()
+
+	rootCmd = &cobra.Command{
+		Use:     "bl",
+		Version: "1.2.3",
+	}
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
+
+	var output bytes.Buffer
+	rootCmd.SetOut(&output)
+	rootCmd.SetArgs([]string{"--version"})
+
+	err := rootCmd.Execute()
+
+	assert.NoError(t, err)
+	assert.Contains(t, output.String(), "bl version 1.2.3")
+
+	versionFlag := rootCmd.Flags().Lookup("version")
+	assert.NotNil(t, versionFlag)
+	assert.Equal(t, "", versionFlag.Shorthand)
+
+	verboseFlag := rootCmd.PersistentFlags().Lookup("verbose")
+	assert.NotNil(t, verboseFlag)
+	assert.Equal(t, "v", verboseFlag.Shorthand)
+}
+
+func TestTrackingPromptCommandExemptions(t *testing.T) {
+	assert.True(t, isTrackingPromptCommandExempt([]string{"bl", "version"}))
+	assert.True(t, isTrackingPromptCommandExempt([]string{"bl", "--version"}))
+	assert.True(t, isTrackingPromptCommandExempt([]string{"bl", "completion"}))
+	assert.True(t, isTrackingPromptCommandExempt([]string{"bl", "__complete"}))
+
+	assert.False(t, isTrackingPromptCommandExempt([]string{"bl"}))
+	assert.False(t, isTrackingPromptCommandExempt([]string{"bl", "-v"}))
+	assert.False(t, isTrackingPromptCommandExempt([]string{"bl", "get"}))
 }
 
 func TestReadWriteVersionCache(t *testing.T) {


### PR DESCRIPTION
- Adds root-level `bl --version` support while preserving `-v` as verbose.
- Keeps `bl version` as the detailed version output with commit and build date.
- Skips the tracking prompt for root version checks so install and agent probes stay non-interactive.

Fixes https://linear.app/blaxel/issue/ENG-2800/support-root-bl-version-in-the-cli

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Moves version/commit/date initialization earlier in `Execute()` (before `promptForTracking()`) and sets `rootCmd.Version` to enable cobra's built-in `--version` flag. Adds `--version` to the tracking prompt exemption list via a new `isTrackingPromptCommandExempt` helper.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit c2f3dde966ca7b42bccaeca3ca589ea9f4f5eb2f.</sup>
<!-- /MENDRAL_SUMMARY -->