### PR TITLE
[codex] Normalize bl upgrade version tags

### DIFF
--- a/cli/upgrade.go
+++ b/cli/upgrade.go
@@ -5,11 +5,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/blaxel-ai/toolkit/cli/core"
 	"github.com/spf13/cobra"
 )
+
+var bareSemverUpgradeVersionPattern = regexp.MustCompile(`^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$`)
 
 func init() {
 	// Auto-register this command
@@ -198,6 +201,7 @@ func upgradeViaBrew(force bool) error {
 // upgradeViaCurl upgrades the CLI using the install script
 func upgradeViaCurl(targetVersion string) error {
 	core.PrintInfo("Upgrading Blaxel CLI via install script...")
+	targetVersion = normalizeUpgradeVersion(targetVersion)
 
 	// Get the current executable path to determine if we need sudo
 	execPath, err := os.Executable()
@@ -254,6 +258,15 @@ func upgradeViaCurl(targetVersion string) error {
 
 	core.PrintSuccess("Blaxel CLI upgraded successfully")
 	return nil
+}
+
+func normalizeUpgradeVersion(targetVersion string) string {
+	trimmedVersion := strings.TrimSpace(targetVersion)
+	if bareSemverUpgradeVersionPattern.MatchString(trimmedVersion) {
+		return "v" + trimmedVersion
+	}
+
+	return trimmedVersion
 }
 
 // needsSudoForPath determines if we need sudo to write to a directory

--- a/cli/upgrade_test.go
+++ b/cli/upgrade_test.go
@@ -24,6 +24,81 @@ func TestUpgradeCmd(t *testing.T) {
 	assert.Equal(t, "false", forceFlag.DefValue)
 }
 
+func TestNormalizeUpgradeVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty version",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "bare semver",
+			input:    "0.1.97",
+			expected: "v0.1.97",
+		},
+		{
+			name:     "already prefixed semver",
+			input:    "v0.1.97",
+			expected: "v0.1.97",
+		},
+		{
+			name:     "bare prerelease semver",
+			input:    "0.1.97-rc.1",
+			expected: "v0.1.97-rc.1",
+		},
+		{
+			name:     "bare build metadata semver",
+			input:    "0.1.97+build.1",
+			expected: "v0.1.97+build.1",
+		},
+		{
+			name:     "version with surrounding space",
+			input:    " 0.1.97 ",
+			expected: "v0.1.97",
+		},
+		{
+			name:     "latest alias",
+			input:    "latest",
+			expected: "latest",
+		},
+		{
+			name:     "latest alias with surrounding space",
+			input:    " latest ",
+			expected: "latest",
+		},
+		{
+			name:     "partial semver",
+			input:    "0.1",
+			expected: "0.1",
+		},
+		{
+			name:     "custom tag",
+			input:    "release-0.1.97",
+			expected: "release-0.1.97",
+		},
+		{
+			name:     "custom tag with surrounding space",
+			input:    " release-0.1.97 ",
+			expected: "release-0.1.97",
+		},
+		{
+			name:     "whitespace only",
+			input:    " \t ",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, normalizeUpgradeVersion(tt.input))
+		})
+	}
+}
+
 func TestNeedsSudoForPath(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
- Normalizes bare semver values like `0.1.97` to the `v0.1.97` release tag before invoking the install-script upgrade path.
- Leaves already-prefixed tags, `latest`, partial versions, and custom tag names unchanged.
- Keeps Homebrew pinned-version behavior out of scope.

Fixes https://linear.app/blaxel/issue/ENG-2801/normalize-bare-versions-in-bl-upgrade-version

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `normalizeUpgradeVersion` to prefix bare semver strings (e.g. `0.1.97`) with `v` before passing them to the curl-based upgrade path. Non-semver inputs like `latest` and custom tags pass through unchanged. Includes table-driven tests covering all documented cases.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 3ce23fbe17e8cca3abefa0dfd5aff8cc4de24c4e.</sup>
<!-- /MENDRAL_SUMMARY -->