### PR TITLE
Refresh bl token before printing credentials

### DIFF
--- a/cli/token.go
+++ b/cli/token.go
@@ -2,7 +2,11 @@ package cli
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 
 	blaxel "github.com/blaxel-ai/sdk-go"
 	"github.com/blaxel-ai/toolkit/cli/core"
@@ -13,6 +17,10 @@ func init() {
 	core.RegisterCommand("token", func() *cobra.Command {
 		return TokenCmd()
 	})
+}
+
+var authHeadersForCredentials = func(ctx context.Context, credentials blaxel.Credentials, workspace string) (map[string]string, error) {
+	return credentials.AuthHeaders(ctx, workspace)
 }
 
 func TokenCmd() *cobra.Command {
@@ -65,9 +73,14 @@ export TOKEN=$(bl token)
 				core.ExitWithError(err)
 			}
 
-			// Get workspace to check if access is allowed + it refreshes the token if needed
-			client := core.GetClient()
-			_, err := client.Workspaces.Get(context.Background(), workspace)
+			// Get workspace to check if access is allowed + it refreshes the token if needed.
+			client, err := blaxel.NewClientFromConfig(workspace)
+			if err != nil {
+				err := fmt.Errorf("failed to create client for workspace '%s': %w", workspace, err)
+				core.PrintError("token", err)
+				core.ExitWithError(err)
+			}
+			_, err = client.Workspaces.Get(context.Background(), workspace)
 			if err != nil {
 				err := fmt.Errorf("failed to get workspace '%s': %w", workspace, err)
 				core.PrintError("token", err)
@@ -75,28 +88,21 @@ export TOKEN=$(bl token)
 			}
 
 			// Load credentials for the workspace
-			credentials, _ := blaxel.LoadCredentials(workspace)
+			credentials, err := blaxel.LoadCredentials(workspace)
+			if err != nil {
+				err := fmt.Errorf("failed to load credentials for workspace '%s': %w", workspace, err)
+				core.PrintError("token", err)
+				core.ExitWithError(err)
+			}
 			if !credentials.IsValid() {
 				err := fmt.Errorf("no valid credentials found for workspace '%s'. Please run 'bl login %s'", workspace, workspace)
 				core.PrintError("token", err)
 				core.ExitWithError(err)
 			}
 
-			// Get token based on credential type
-			token := ""
-			if credentials.APIKey != "" {
-				token = credentials.APIKey
-			} else if credentials.AccessToken != "" {
-				// TODO: Check if token needs refresh and refresh if needed
-				token = credentials.AccessToken
-			} else if credentials.ClientCredentials != "" {
-				// For client credentials, we'd need to exchange for an access token
-				// For now, just return the client credentials value
-				token = credentials.ClientCredentials
-			}
-
-			if token == "" {
-				err := fmt.Errorf("no token found in credentials")
+			token, err := tokenForCredentials(context.Background(), workspace, credentials)
+			if err != nil {
+				err := fmt.Errorf("failed to retrieve token for workspace '%s': %w", workspace, err)
 				core.PrintError("token", err)
 				core.ExitWithError(err)
 			}
@@ -107,4 +113,54 @@ export TOKEN=$(bl token)
 	}
 
 	return cmd
+}
+
+func tokenForCredentials(ctx context.Context, workspace string, credentials blaxel.Credentials) (string, error) {
+	headers, err := authHeadersForCredentials(ctx, credentials, workspace)
+	if err != nil {
+		return "", err
+	}
+
+	token := bearerTokenFromHeaders(headers)
+	if token == "" {
+		return "", fmt.Errorf("no bearer token found in credentials")
+	}
+
+	if expired, ok := jwtExpired(token, time.Now()); ok && expired && credentials.APIKey == "" {
+		return "", fmt.Errorf("access token is expired and could not be refreshed. Please run 'bl login %s'", workspace)
+	}
+
+	return token, nil
+}
+
+func bearerTokenFromHeaders(headers map[string]string) string {
+	for _, name := range []string{"Authorization", "X-Blaxel-Authorization"} {
+		value := strings.TrimSpace(headers[name])
+		if token, ok := strings.CutPrefix(value, "Bearer "); ok {
+			return strings.TrimSpace(token)
+		}
+	}
+	return ""
+}
+
+func jwtExpired(token string, now time.Time) (bool, bool) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return false, false
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return false, false
+	}
+
+	var claims struct {
+		Exp float64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil || claims.Exp == 0 {
+		return false, false
+	}
+
+	expiresAt := time.Unix(int64(claims.Exp), 0)
+	return !expiresAt.After(now), true
 }

--- a/cli/token_test.go
+++ b/cli/token_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	blaxel "github.com/blaxel-ai/sdk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenForCredentialsUsesRefreshedBearer(t *testing.T) {
+	storedToken := testJWT(t, time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+	const refreshedToken = "fresh-access-token"
+
+	previous := authHeadersForCredentials
+	authHeadersForCredentials = func(ctx context.Context, credentials blaxel.Credentials, workspace string) (map[string]string, error) {
+		assert.Equal(t, "main", workspace)
+		assert.Equal(t, storedToken, credentials.AccessToken)
+		assert.Equal(t, "refresh-token", credentials.RefreshToken)
+		return map[string]string{
+			"X-Blaxel-Authorization": "Bearer " + refreshedToken,
+		}, nil
+	}
+	t.Cleanup(func() { authHeadersForCredentials = previous })
+
+	token, err := tokenForCredentials(context.Background(), "main", blaxel.Credentials{
+		AccessToken:  storedToken,
+		RefreshToken: "refresh-token",
+		ExpiresIn:    7200,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, refreshedToken, token)
+}
+
+func TestTokenForCredentialsRejectsExpiredUnrefreshedBearer(t *testing.T) {
+	expiredToken := testJWT(t, time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+
+	previous := authHeadersForCredentials
+	authHeadersForCredentials = func(ctx context.Context, credentials blaxel.Credentials, workspace string) (map[string]string, error) {
+		return map[string]string{
+			"X-Blaxel-Authorization": "Bearer " + credentials.AccessToken,
+		}, nil
+	}
+	t.Cleanup(func() { authHeadersForCredentials = previous })
+
+	token, err := tokenForCredentials(context.Background(), "main", blaxel.Credentials{
+		AccessToken: expiredToken,
+	})
+
+	require.Error(t, err)
+	assert.Empty(t, token)
+	assert.Contains(t, err.Error(), "bl login main")
+}
+
+func TestBearerTokenFromHeaders(t *testing.T) {
+	assert.Equal(t, "api-key", bearerTokenFromHeaders(map[string]string{
+		"X-Blaxel-Authorization": "Bearer api-key",
+	}))
+	assert.Equal(t, "access-token", bearerTokenFromHeaders(map[string]string{
+		"Authorization": "Bearer access-token",
+	}))
+	assert.Empty(t, bearerTokenFromHeaders(map[string]string{
+		"Authorization": "Basic nope",
+	}))
+}
+
+func testJWT(t *testing.T, issuedAt time.Time, expiresAt time.Time) string {
+	t.Helper()
+
+	header := map[string]string{
+		"alg": "none",
+		"typ": "JWT",
+	}
+	claims := map[string]int64{
+		"iat": issuedAt.Unix(),
+		"exp": expiresAt.Unix(),
+	}
+
+	return fmt.Sprintf("%s.%s.",
+		testJWTPart(t, header),
+		testJWTPart(t, claims),
+	)
+}
+
+func testJWTPart(t *testing.T, value interface{}) string {
+	t.Helper()
+
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+
+	return base64.RawURLEncoding.EncodeToString(data)
+}


### PR DESCRIPTION
- Refreshes OAuth credentials through the SDK auth path before `bl token` prints a bearer token.
- Validates the requested workspace directly so positional `bl token <workspace>` does not rely on the root client workspace.
- Adds regression coverage for refreshed bearer output and expired-token rejection.