### PR TITLE
docs: sync CLI reference with latest commands

### DIFF
--- a/docs/bl.md
+++ b/docs/bl.md
@@ -25,6 +25,7 @@ Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
 * [bl connect](bl_connect.md)	 - Open an interactive terminal session to a sandbox
 * [bl delete](bl_delete.md)	 - Delete resources from your workspace
 * [bl deploy](bl_deploy.md)	 - Build, push, and deploy your project to Blaxel
+* [bl drive](bl_drive.md)	 - Manage drives and drive mounts on sandboxes
 * [bl get](bl_get.md)	 - List or retrieve Blaxel resources in your workspace
 * [bl login](bl_login.md)	 - Login to Blaxel
 * [bl logout](bl_logout.md)	 - Logout from Blaxel

--- a/docs/bl_deploy.md
+++ b/docs/bl_deploy.md
@@ -23,6 +23,10 @@ A blaxel.toml configuration file is required. By default, the command looks
 for it in the current directory. Use -d to specify a subdirectory containing
 the blaxel.toml (useful for monorepo setups).
 
+If the blaxel.toml contains an 'image' field pointing to a registry image,
+the platform will pull the image and transform it via metamorph before deploying.
+For private registries, supply credentials via --registry-cred or --docker-config.
+
 Interactive vs Non-Interactive:
 - Interactive (default): Shows live logs and deployment progress with TUI
 - Non-interactive (--yes or CI): Runs without interactive UI, suitable for automation
@@ -88,7 +92,7 @@ bl deploy [flags]
   -c, --registry-cred stringArray   Registry credentials (format: registry=username:password, repeatable)
   -s, --secrets strings             Secrets to deploy
       --skip-build                  Skip the build step
-      --timeout string              Timeout for build and deployment monitoring (e.g. 30m, 1h). Defaults to 15m
+      --timeout string              Timeout for build and deployment monitoring (e.g. 30m, 1h). Defaults to 1h
   -t, --type string                 Resource type (sandbox, agent, function, job). Defaults to blaxel.toml type or 'sandbox'
   -y, --yes                         Skip interactive mode
 ```

--- a/docs/bl_drive.md
+++ b/docs/bl_drive.md
@@ -1,0 +1,75 @@
+---
+title: "bl drive"
+slug: bl_drive
+---
+## bl drive
+
+Manage drives and drive mounts on sandboxes
+
+### Synopsis
+
+Manage drives and drive mounts on sandboxes.
+
+Drive CRUD:
+  bl drive list                       List all drives in the workspace
+  bl drive get <name>                 Get details of a specific drive
+  bl drive create                     Create a new drive
+  bl drive delete <name>              Delete a drive
+
+Sandbox mount operations:
+  bl drive mount --sandbox <s> ...    Mount a drive to a running sandbox
+  bl drive unmount --sandbox <s> ...  Unmount a drive from a running sandbox
+  bl drive mounts --sandbox <s>       List drives mounted in a running sandbox
+
+### Examples
+
+```
+  # List all drives
+  bl drive list
+
+  # Get details of a drive
+  bl drive get my-drive
+
+  # Create a new drive
+  bl drive create --name my-drive --region us-pdx-1
+
+  # Delete a drive
+  bl drive delete my-drive
+
+  # Mount a drive to a sandbox
+  bl drive mount --sandbox my-sandbox --drive my-drive --mount-path /mnt/data
+
+  # Unmount a drive from a sandbox
+  bl drive unmount --sandbox my-sandbox --mount-path /mnt/data
+
+  # List mounted drives in a sandbox
+  bl drive mounts --sandbox my-sandbox
+```
+
+### Options
+
+```
+  -h, --help   help for drive
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string          Output format. One of: pretty,yaml,json,table
+      --skip-version-warning   Skip version warning
+  -u, --utc                    Enable UTC timezone
+  -v, --verbose                Enable verbose output
+  -w, --workspace string       Specify the workspace name
+```
+
+### SEE ALSO
+
+* [bl](bl.md)	 - Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
+* [bl drive create](bl_drive_create.md)	 - Create a new drive
+* [bl drive delete](bl_drive_delete.md)	 - Delete a drive
+* [bl drive get](bl_drive_get.md)	 - Get details of a specific drive
+* [bl drive list](bl_drive_list.md)	 - List all drives in the workspace
+* [bl drive mount](bl_drive_mount.md)	 - Mount a drive to a sandbox
+* [bl drive mounts](bl_drive_mounts.md)	 - List mounted drives in a sandbox
+* [bl drive unmount](bl_drive_unmount.md)	 - Unmount a drive from a sandbox
+

--- a/docs/bl_drive_create.md
+++ b/docs/bl_drive_create.md
@@ -1,0 +1,49 @@
+---
+title: "bl drive create"
+slug: bl_drive_create
+---
+## bl drive create
+
+Create a new drive
+
+### Synopsis
+
+Create a new drive in the current workspace.
+
+```
+bl drive create [flags]
+```
+
+### Examples
+
+```
+  # Create a drive in a specific region
+  bl drive create --name my-drive --region us-pdx-1
+
+  # Create a drive with a size limit (in GB)
+  bl drive create --name my-drive --region us-pdx-1 --size 10
+```
+
+### Options
+
+```
+  -h, --help            help for create
+      --name string     Name of the drive
+      --region string   Deployment region (e.g., us-pdx-1, eu-lon-1)
+      --size int        Size limit in GB (optional, 0 for unlimited)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string          Output format. One of: pretty,yaml,json,table
+      --skip-version-warning   Skip version warning
+  -u, --utc                    Enable UTC timezone
+  -v, --verbose                Enable verbose output
+  -w, --workspace string       Specify the workspace name
+```
+
+### SEE ALSO
+
+* [bl drive](bl_drive.md)	 - Manage drives and drive mounts on sandboxes
+

--- a/docs/bl_drive_delete.md
+++ b/docs/bl_drive_delete.md
@@ -1,0 +1,43 @@
+---
+title: "bl drive delete"
+slug: bl_drive_delete
+---
+## bl drive delete
+
+Delete a drive
+
+### Synopsis
+
+Delete a drive from the current workspace.
+
+```
+bl drive delete <name> [flags]
+```
+
+### Examples
+
+```
+  # Delete a drive
+  bl drive delete my-drive
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string          Output format. One of: pretty,yaml,json,table
+      --skip-version-warning   Skip version warning
+  -u, --utc                    Enable UTC timezone
+  -v, --verbose                Enable verbose output
+  -w, --workspace string       Specify the workspace name
+```
+
+### SEE ALSO
+
+* [bl drive](bl_drive.md)	 - Manage drives and drive mounts on sandboxes
+

--- a/docs/bl_drive_get.md
+++ b/docs/bl_drive_get.md
@@ -1,0 +1,46 @@
+---
+title: "bl drive get"
+slug: bl_drive_get
+---
+## bl drive get
+
+Get details of a specific drive
+
+### Synopsis
+
+Get detailed information about a drive in the current workspace.
+
+```
+bl drive get <name> [flags]
+```
+
+### Examples
+
+```
+  # Get drive details
+  bl drive get my-drive
+
+  # Get drive details in JSON format
+  bl drive get my-drive -o json
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string          Output format. One of: pretty,yaml,json,table
+      --skip-version-warning   Skip version warning
+  -u, --utc                    Enable UTC timezone
+  -v, --verbose                Enable verbose output
+  -w, --workspace string       Specify the workspace name
+```
+
+### SEE ALSO
+
+* [bl drive](bl_drive.md)	 - Manage drives and drive mounts on sandboxes
+

--- a/docs/bl_drive_list.md
+++ b/docs/bl_drive_list.md
@@ -1,0 +1,46 @@
+---
+title: "bl drive list"
+slug: bl_drive_list
+---
+## bl drive list
+
+List all drives in the workspace
+
+### Synopsis
+
+List all drives in the current workspace.
+
+```
+bl drive list [flags]
+```
+
+### Examples
+
+```
+  # List all drives
+  bl drive list
+
+  # List drives in JSON format
+  bl drive list -o json
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string          Output format. One of: pretty,yaml,json,table
+      --skip-version-warning   Skip version warning
+  -u, --utc                    Enable UTC timezone
+  -v, --verbose                Enable verbose output
+  -w, --workspace string       Specify the workspace name
+```
+
+### SEE ALSO
+
+* [bl drive](bl_drive.md)	 - Manage drives and drive mounts on sandboxes
+

--- a/docs/bl_drive_mount.md
+++ b/docs/bl_drive_mount.md
@@ -1,0 +1,62 @@
+---
+title: "bl drive mount"
+slug: bl_drive_mount
+---
+## bl drive mount
+
+Mount a drive to a sandbox
+
+### Synopsis
+
+Mount or re-mount a drive to a sandbox environment.
+
+This command attaches an agent drive to a local path inside the sandbox using
+the blfs filesystem. It can be used as a recovery tool when mounts are lost.
+
+```
+bl drive mount [flags]
+```
+
+### Examples
+
+```
+  # Mount a drive with default settings
+  bl drive mount --sandbox my-sandbox --drive my-drive --mount-path /mnt/data
+
+  # Mount a subdirectory of the drive
+  bl drive mount --sandbox my-sandbox --drive my-drive --mount-path /mnt/data --drive-path /subdir
+
+  # Mount as read-only
+  bl drive mount --sandbox my-sandbox --drive my-drive --mount-path /mnt/data --read-only
+
+  # Mount with UID/GID mapping
+  bl drive mount --sandbox my-sandbox --drive my-drive --mount-path /mnt/data --uid-map 1000 --gid-map 1000
+```
+
+### Options
+
+```
+      --drive string        Name of the drive to mount
+      --drive-path string   Subdirectory within the drive to mount (optional, defaults to /)
+      --gid-map string      Local GID to map (filer GID is always 0)
+  -h, --help                help for mount
+      --mount-path string   Local path inside the sandbox to mount the drive
+      --read-only           Mount the drive as read-only
+      --sandbox string      Name of the sandbox
+      --uid-map string      Local UID to map (filer UID is always 0)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string          Output format. One of: pretty,yaml,json,table
+      --skip-version-warning   Skip version warning
+  -u, --utc                    Enable UTC timezone
+  -v, --verbose                Enable verbose output
+  -w, --workspace string       Specify the workspace name
+```
+
+### SEE ALSO
+
+* [bl drive](bl_drive.md)	 - Manage drives and drive mounts on sandboxes
+

--- a/docs/bl_drive_mounts.md
+++ b/docs/bl_drive_mounts.md
@@ -1,0 +1,44 @@
+---
+title: "bl drive mounts"
+slug: bl_drive_mounts
+---
+## bl drive mounts
+
+List mounted drives in a sandbox
+
+### Synopsis
+
+List all currently mounted drives in a sandbox environment.
+
+```
+bl drive mounts [flags]
+```
+
+### Examples
+
+```
+  # List all mounted drives
+  bl drive mounts --sandbox my-sandbox
+```
+
+### Options
+
+```
+  -h, --help             help for mounts
+      --sandbox string   Name of the sandbox
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string          Output format. One of: pretty,yaml,json,table
+      --skip-version-warning   Skip version warning
+  -u, --utc                    Enable UTC timezone
+  -v, --verbose                Enable verbose output
+  -w, --workspace string       Specify the workspace name
+```
+
+### SEE ALSO
+
+* [bl drive](bl_drive.md)	 - Manage drives and drive mounts on sandboxes
+

--- a/docs/bl_drive_unmount.md
+++ b/docs/bl_drive_unmount.md
@@ -1,0 +1,45 @@
+---
+title: "bl drive unmount"
+slug: bl_drive_unmount
+---
+## bl drive unmount
+
+Unmount a drive from a sandbox
+
+### Synopsis
+
+Unmount a previously mounted drive from the specified local path inside a sandbox.
+
+```
+bl drive unmount [flags]
+```
+
+### Examples
+
+```
+  # Unmount a drive
+  bl drive unmount --sandbox my-sandbox --mount-path /mnt/data
+```
+
+### Options
+
+```
+  -h, --help                help for unmount
+      --mount-path string   Mount path to detach (must start with /)
+      --sandbox string      Name of the sandbox
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string          Output format. One of: pretty,yaml,json,table
+      --skip-version-warning   Skip version warning
+  -u, --utc                    Enable UTC timezone
+  -v, --verbose                Enable verbose output
+  -w, --workspace string       Specify the workspace name
+```
+
+### SEE ALSO
+
+* [bl drive](bl_drive.md)	 - Manage drives and drive mounts on sandboxes
+

--- a/docs/bl_new.md
+++ b/docs/bl_new.md
@@ -69,6 +69,13 @@ bl new [type] [directory] [flags]
   # Create MCP server with default template (non-interactive)
   bl new mcp my-mcp-server -y -t mcp-py
 
+  # Choose a sandbox type interactively
+  bl new sandbox
+
+  # Create Claude Code or Codex sandboxes non-interactively
+  bl new sandbox my-claude-sandbox -t claude-code -y
+  bl new sandbox my-codex-sandbox -t codex -y
+
   # Create job with specific template
   bl new job my-batch-job -t jobs-py
 

--- a/docs/bl_push.md
+++ b/docs/bl_push.md
@@ -21,7 +21,13 @@ The process includes:
 4. Building container image
 5. Streaming build logs until the image is ready
 
-You must run this command from a directory containing a blaxel.toml file.
+If the blaxel.toml contains an 'image' field pointing to a registry image
+(e.g. docker.io/myorg/myapp:latest), the platform will pull the image and
+transform it for the target runtime via metamorph. If the same image was
+already built, the build is triggered again by default. Use --skip-build to
+skip the build if the image was already built.
+
+For private registries, supply credentials via --registry-cred or --docker-config.
 
 ```
 bl push [flags]
@@ -42,6 +48,12 @@ bl push [flags]
   # Push specifying a resource type
   bl push --type agent
 
+  # Push from a private registry (credentials for blaxel.toml image field)
+  bl push --registry-cred ghcr.io=user:token
+
+  # Skip rebuild if image was already built
+  bl push --skip-build
+
   # Push with a longer timeout for large images
   bl push --timeout 30m
 ```
@@ -55,7 +67,8 @@ bl push [flags]
   -h, --help                        help for push
   -n, --name string                 Name for the image (defaults to directory name)
   -c, --registry-cred stringArray   Registry credentials (format: registry=username:password, repeatable)
-      --timeout string              Timeout for build log monitoring (e.g. 30m, 1h). Defaults to 15m
+      --skip-build                  Skip the image build step (use existing built image if available)
+      --timeout string              Timeout for build log monitoring (e.g. 30m, 1h). Defaults to 1h
   -t, --type string                 Resource type (agent, function, sandbox, job). Defaults to blaxel.toml type; required if not set
   -y, --yes                         Skip interactive mode
 ```


### PR DESCRIPTION
ENG-2859

## Summary

- Add `bl drive` command group and all subcommands: `create`, `delete`, `get`, `list`, `mount`, `mounts`, `unmount`
- Update `bl.md` index to include the new `drive` entry
- Fix default timeout in `bl deploy` and `bl push` (15m → 1h)
- Document `image` field / metamorph support and `--skip-build` flag in `bl push` and `bl deploy`
- Add sandbox examples for `claude-code` and `codex` templates in `bl new`

## Test plan

- [ ] Verify all new drive docs render correctly in the docs site
- [ ] Check cross-links between `bl drive` and subcommand pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds documentation for the new `bl drive` command group (7 subcommands: create, delete, get, list, mount, mounts, unmount), updates `bl.md` index, corrects the default timeout from 15m to 1h in `bl deploy` and `bl push`, documents the `image`/metamorph workflow and `--skip-build` flag, and adds sandbox template examples for `claude-code` and `codex`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit c4e0f1ef3bb4cf4ad51756e8e8ddb6636edc6abd.</sup>
<!-- /MENDRAL_SUMMARY -->