### PR TITLE
fix(cli): recognize named-stage sandbox-api copies in the Dockerfile check

### DIFF
--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -506,16 +507,9 @@ func ValidateBuildConfig(cwd, folder string, config core.Config) string {
 		}
 
 		// Dockerfile exists, check if sandbox-api binary is available in the image.
-		// Valid patterns:
-		// 1. Base image from blaxel (already contains sandbox-api): FROM ghcr.io/blaxel-ai/sandbox
-		// 2. Multi-stage copy of the binary: COPY --from=ghcr.io/blaxel-ai/sandbox
 		dockerfileContent, err := os.ReadFile(dockerfilePath)
 		if err == nil {
-			content := string(dockerfileContent)
-			hasBlaxelSandboxBase := strings.Contains(content, "FROM ghcr.io/blaxel-ai/sandbox")
-			hasCopySandboxAPI := strings.Contains(content, "COPY --from=ghcr.io/blaxel-ai/sandbox")
-
-			if !hasBlaxelSandboxBase && !hasCopySandboxAPI {
+			if !dockerfileProvidesSandboxAPI(string(dockerfileContent)) {
 				var warningMsg strings.Builder
 				warningMsg.WriteString("⚠️  Sandbox Configuration Warning\n")
 				warningMsg.WriteString("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n")
@@ -592,6 +586,68 @@ func ValidateBuildConfig(cwd, folder string, config core.Config) string {
 	warningMsg.WriteString("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 
 	return warningMsg.String()
+}
+
+// dockerfileProvidesSandboxAPI reports whether a sandbox Dockerfile makes the
+// sandbox-api binary available in the final image. Valid patterns:
+//  1. The final stage builds on a Blaxel sandbox base image:
+//     FROM ghcr.io/blaxel-ai/sandbox
+//  2. A copy of the binary, directly from the image or via a named or indexed
+//     build stage based on it:
+//     FROM ghcr.io/blaxel-ai/sandbox:latest AS blaxel-sandbox
+//     COPY --from=blaxel-sandbox /sandbox-api /usr/local/bin/sandbox-api
+//
+// FROM flags such as --platform are ignored.
+func dockerfileProvidesSandboxAPI(content string) bool {
+	const sandboxImage = "ghcr.io/blaxel-ai/sandbox"
+	sandboxStageNames := map[string]bool{}
+	var stageIsSandbox []bool
+	for line := range strings.Lines(content) {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) == 0 {
+			continue
+		}
+		switch strings.ToUpper(fields[0]) {
+		case "FROM":
+			image := ""
+			alias := ""
+			for i := 1; i < len(fields); i++ {
+				field := fields[i]
+				if strings.HasPrefix(field, "--") {
+					continue // FROM flags such as --platform
+				}
+				if image == "" {
+					image = field
+				} else if strings.EqualFold(field, "AS") && i+1 < len(fields) {
+					alias = fields[i+1]
+					break
+				}
+			}
+			// A stage is sandbox-based when it builds on the image itself or
+			// on an earlier sandbox-based stage. Stage names are case-insensitive.
+			isSandbox := strings.Contains(image, sandboxImage) ||
+				sandboxStageNames[strings.ToLower(image)]
+			stageIsSandbox = append(stageIsSandbox, isSandbox)
+			if isSandbox && alias != "" {
+				sandboxStageNames[strings.ToLower(alias)] = true
+			}
+		case "COPY":
+			for _, field := range fields[1:] {
+				ref, ok := strings.CutPrefix(field, "--from=")
+				if !ok {
+					continue
+				}
+				if strings.Contains(ref, sandboxImage) || sandboxStageNames[strings.ToLower(ref)] {
+					return true
+				}
+				if index, err := strconv.Atoi(ref); err == nil &&
+					index >= 0 && index < len(stageIsSandbox) && stageIsSandbox[index] {
+					return true
+				}
+			}
+		}
+	}
+	return len(stageIsSandbox) > 0 && stageIsSandbox[len(stageIsSandbox)-1]
 }
 
 func (d *Deployment) GenerateDeployment(skipBuild bool) core.Result {

--- a/cli/deploy_test.go
+++ b/cli/deploy_test.go
@@ -677,3 +677,85 @@ workspace = "test-workspace"
 	assert.Equal(t, "my-function", config.Name)
 	assert.Equal(t, "function", config.Type)
 }
+
+func TestDockerfileProvidesSandboxAPI(t *testing.T) {
+	tests := []struct {
+		name       string
+		dockerfile string
+		want       bool
+	}{
+		{
+			name:       "blaxel sandbox base image",
+			dockerfile: "FROM ghcr.io/blaxel-ai/sandbox:latest\n",
+			want:       true,
+		},
+		{
+			name:       "blaxel sandbox base image with platform flag",
+			dockerfile: "FROM --platform=linux/amd64 ghcr.io/blaxel-ai/sandbox:latest\n",
+			want:       true,
+		},
+		{
+			name: "direct multi-stage copy from the image",
+			dockerfile: `FROM debian:bookworm-slim
+COPY --from=ghcr.io/blaxel-ai/sandbox:latest /sandbox-api /usr/local/bin/sandbox-api
+`,
+			want: true,
+		},
+		{
+			name: "copy from a named build stage",
+			dockerfile: `FROM --platform=linux/amd64 ghcr.io/blaxel-ai/sandbox:latest AS blaxel-sandbox
+FROM --platform=linux/amd64 node:22-bookworm-slim
+COPY --from=blaxel-sandbox /sandbox-api /usr/local/bin/sandbox-api
+`,
+			want: true,
+		},
+		{
+			name: "stage names are case-insensitive",
+			dockerfile: `FROM ghcr.io/blaxel-ai/sandbox:latest AS Blaxel-Sandbox
+FROM debian:bookworm-slim
+COPY --from=BLAXEL-SANDBOX /sandbox-api /usr/local/bin/sandbox-api
+`,
+			want: true,
+		},
+		{
+			name: "copy from an indexed build stage",
+			dockerfile: `FROM ghcr.io/blaxel-ai/sandbox:latest
+FROM debian:bookworm-slim
+COPY --from=0 /sandbox-api /usr/local/bin/sandbox-api
+`,
+			want: true,
+		},
+		{
+			name: "copy from a stage built on a sandbox stage",
+			dockerfile: `FROM ghcr.io/blaxel-ai/sandbox:latest AS base
+FROM base AS tools
+FROM debian:bookworm-slim
+COPY --from=tools /sandbox-api /usr/local/bin/sandbox-api
+`,
+			want: true,
+		},
+		{
+			name:       "plain image without the binary",
+			dockerfile: "FROM debian:bookworm-slim\nRUN apt-get update\n",
+			want:       false,
+		},
+		{
+			name: "sandbox stage that is never copied from",
+			dockerfile: `FROM ghcr.io/blaxel-ai/sandbox:latest AS unused
+FROM debian:bookworm-slim
+COPY --from=somewhere-else /thing /thing
+`,
+			want: false,
+		},
+		{
+			name:       "empty dockerfile",
+			dockerfile: "",
+			want:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, dockerfileProvidesSandboxAPI(tt.dockerfile))
+		})
+	}
+}


### PR DESCRIPTION
Fixes ENG-2784

- `bl push`/`bl deploy` warned "sandbox-api binary is not available in the image" on valid sandbox Dockerfiles that copy the binary via a named build stage (`FROM ghcr.io/blaxel-ai/sandbox:latest AS x` + `COPY --from=x`) or use `FROM --platform=...`, because the check was substring matching.
- Replaces it with a small Dockerfile parse that tracks sandbox-based stages (named, indexed, and stage-on-stage) and FROM flags; plain Dockerfiles without the binary still warn.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Replaces naive substring matching for sandbox-api Dockerfile validation with a proper parser that tracks named/indexed build stages, handles FROM flags, and supports stage-on-stage inheritance.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 3d78f9107a6b33a636656537e242e9def228c173.</sup>
<!-- /MENDRAL_SUMMARY -->