### PR TITLE
Detect Go entrypoints under cmd directories

### DIFF
--- a/cli/core/utils.go
+++ b/cli/core/utils.go
@@ -246,6 +246,12 @@ func HasPythonEntryFile(directory string) bool {
 
 // HasGoEntryFile checks if common Go entry files exist in the given directory
 func HasGoEntryFile(directory string) bool {
+	entryFile, err := FindGoEntryFile(directory)
+	return err == nil && entryFile != ""
+}
+
+// FindGoEntryFile finds a single automatic Go entrypoint in the given directory.
+func FindGoEntryFile(directory string) (string, error) {
 	files := []string{
 		"main.go",
 		"src/main.go",
@@ -253,10 +259,29 @@ func HasGoEntryFile(directory string) bool {
 	}
 	for _, f := range files {
 		if _, err := os.Stat(filepath.Join(directory, f)); err == nil {
-			return true
+			return f, nil
 		}
 	}
-	return false
+
+	matches, err := filepath.Glob(filepath.Join(directory, "cmd", "*", "main.go"))
+	if err != nil {
+		return "", fmt.Errorf("error finding Go entrypoint: %w", err)
+	}
+	candidates := make([]string, 0, len(matches))
+	for _, match := range matches {
+		rel, err := filepath.Rel(directory, match)
+		if err != nil {
+			return "", fmt.Errorf("error finding Go entrypoint: %w", err)
+		}
+		candidates = append(candidates, filepath.ToSlash(rel))
+	}
+	if len(candidates) == 0 {
+		return "", nil
+	}
+	if len(candidates) > 1 {
+		return "", fmt.Errorf("multiple Go entrypoints found under cmd/*/main.go (%s); configure [entrypoint] prod = \"go run ./cmd/<name>\" in blaxel.toml", strings.Join(candidates, ", "))
+	}
+	return candidates[0], nil
 }
 
 // HasTypeScriptEntryFile checks if common TypeScript/JavaScript entry files exist in the given directory

--- a/cli/core/utils.go
+++ b/cli/core/utils.go
@@ -250,6 +250,8 @@ func HasGoEntryFile(directory string) bool {
 	return err == nil && entryFile != ""
 }
 
+var safeGoCmdEntrypointPattern = regexp.MustCompile(`^cmd/[A-Za-z0-9_.-]+/main\.go$`)
+
 // FindGoEntryFile finds a single automatic Go entrypoint in the given directory.
 func FindGoEntryFile(directory string) (string, error) {
 	files := []string{
@@ -273,7 +275,11 @@ func FindGoEntryFile(directory string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("error finding Go entrypoint: %w", err)
 		}
-		candidates = append(candidates, filepath.ToSlash(rel))
+		rel = filepath.ToSlash(rel)
+		if !safeGoCmdEntrypointPattern.MatchString(rel) {
+			return "", fmt.Errorf("unsupported Go entrypoint path %q; automatic cmd/*/main.go detection only supports command directory names with letters, numbers, dots, underscores, and hyphens; configure [entrypoint] prod = \"go run ./cmd/<name>\" in blaxel.toml", rel)
+		}
+		candidates = append(candidates, rel)
 	}
 	if len(candidates) == 0 {
 		return "", nil

--- a/cli/core/utils_test.go
+++ b/cli/core/utils_test.go
@@ -303,12 +303,73 @@ func TestHasGoEntryFile(t *testing.T) {
 		assert.True(t, HasGoEntryFile(dir))
 	})
 
+	t.Run("finds cmd named main.go", func(t *testing.T) {
+		dir := filepath.Join(tempDir, "cmd_named_main")
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "dummy_mcp"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd", "dummy_mcp", "main.go"), []byte("package main"), 0644))
+
+		assert.True(t, HasGoEntryFile(dir))
+	})
+
 	t.Run("returns false when no entry file", func(t *testing.T) {
 		dir := filepath.Join(tempDir, "no_entry")
 		require.NoError(t, os.MkdirAll(dir, 0755))
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "utils.go"), []byte("package utils"), 0644))
 
 		assert.False(t, HasGoEntryFile(dir))
+	})
+
+	t.Run("returns false when cmd entrypoint is ambiguous", func(t *testing.T) {
+		dir := filepath.Join(tempDir, "ambiguous_cmd")
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "api"), 0755))
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "worker"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd", "api", "main.go"), []byte("package main"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd", "worker", "main.go"), []byte("package main"), 0644))
+
+		assert.False(t, HasGoEntryFile(dir))
+	})
+}
+
+func TestFindGoEntryFile(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "find_go_entry_test")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	t.Run("prefers conventional main.go", func(t *testing.T) {
+		dir := filepath.Join(tempDir, "prefer_conventional")
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "dummy_mcp"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd", "dummy_mcp", "main.go"), []byte("package main"), 0644))
+
+		entryFile, err := FindGoEntryFile(dir)
+		require.NoError(t, err)
+		assert.Equal(t, "main.go", entryFile)
+	})
+
+	t.Run("finds single cmd named entrypoint", func(t *testing.T) {
+		dir := filepath.Join(tempDir, "cmd_named")
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "dummy_mcp"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd", "dummy_mcp", "main.go"), []byte("package main"), 0644))
+
+		entryFile, err := FindGoEntryFile(dir)
+		require.NoError(t, err)
+		assert.Equal(t, "cmd/dummy_mcp/main.go", entryFile)
+	})
+
+	t.Run("errors on multiple cmd named entrypoints", func(t *testing.T) {
+		dir := filepath.Join(tempDir, "multiple_cmd")
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "api"), 0755))
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "worker"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd", "api", "main.go"), []byte("package main"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd", "worker", "main.go"), []byte("package main"), 0644))
+
+		entryFile, err := FindGoEntryFile(dir)
+		assert.Empty(t, entryFile)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple Go entrypoints")
+		assert.Contains(t, err.Error(), "cmd/api/main.go")
+		assert.Contains(t, err.Error(), "cmd/worker/main.go")
+		assert.Contains(t, err.Error(), "[entrypoint]")
 	})
 }
 

--- a/cli/core/utils_test.go
+++ b/cli/core/utils_test.go
@@ -371,6 +371,19 @@ func TestFindGoEntryFile(t *testing.T) {
 		assert.Contains(t, err.Error(), "cmd/worker/main.go")
 		assert.Contains(t, err.Error(), "[entrypoint]")
 	})
+
+	t.Run("rejects unsafe cmd named entrypoint", func(t *testing.T) {
+		dir := filepath.Join(tempDir, "unsafe_cmd")
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "dummy;echo pwned"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd", "dummy;echo pwned", "main.go"), []byte("package main"), 0644))
+
+		entryFile, err := FindGoEntryFile(dir)
+		assert.Empty(t, entryFile)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported Go entrypoint path")
+		assert.Contains(t, err.Error(), "cmd/dummy;echo pwned/main.go")
+		assert.Contains(t, err.Error(), "[entrypoint]")
+	})
 }
 
 func TestHasTypeScriptEntryFile(t *testing.T) {

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -572,7 +572,7 @@ func ValidateBuildConfig(cwd, folder string, config core.Config) string {
 			fmt.Fprintf(&warningMsg, "  • Add automatic entrypoint %s OR\n", pythonFiles)
 			warningMsg.WriteString(entrypointSection)
 		case "go":
-			goFiles := codeColor.Sprint("main.go, src/main.go, cmd/main.go")
+			goFiles := codeColor.Sprint("main.go, src/main.go, cmd/main.go, cmd/<name>/main.go")
 			fmt.Fprintf(&warningMsg, "  • Add automatic entrypoint %s OR\n", goFiles)
 			warningMsg.WriteString(entrypointSection)
 		case "typescript":

--- a/cli/server/commands_go.go
+++ b/cli/server/commands_go.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/blaxel-ai/toolkit/cli/core"
@@ -77,5 +78,20 @@ func findGoRootCmdAsString(cfg RootCmdConfig) ([]string, error) {
 		}
 		return strings.Split(cfg.Entrypoint.Production, " "), nil
 	}
+	entryFile, err := core.FindGoEntryFile(cfg.Folder)
+	if err != nil {
+		return nil, err
+	}
+	if entryFile != "" {
+		return []string{"go", "run", goRunTargetFromEntryFile(entryFile)}, nil
+	}
 	return nil, fmt.Errorf("entrypoint not found in config")
+}
+
+func goRunTargetFromEntryFile(entryFile string) string {
+	entryDir := filepath.Dir(entryFile)
+	if entryDir == "." {
+		return "."
+	}
+	return "./" + filepath.ToSlash(entryDir)
 }

--- a/cli/server/commands_test.go
+++ b/cli/server/commands_test.go
@@ -261,6 +261,63 @@ func TestFindRootCmdAsStringWithAutoDetection(t *testing.T) {
 			assert.NotEmpty(t, cmd)
 		}
 	})
+
+	t.Run("detects go with cmd named main.go", func(t *testing.T) {
+		dir := filepath.Join(tempDir, "go_cmd_named")
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "dummy_mcp"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/dummy"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd", "dummy_mcp", "main.go"), []byte("package main"), 0644))
+
+		cfg := RootCmdConfig{
+			Folder:    dir,
+			Hotreload: false,
+		}
+
+		cmd, err := FindRootCmdAsString(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"go", "run", "./cmd/dummy_mcp"}, cmd)
+	})
+
+	t.Run("errors when go cmd entrypoint is ambiguous", func(t *testing.T) {
+		dir := filepath.Join(tempDir, "go_cmd_ambiguous")
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "api"), 0755))
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "worker"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/dummy"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd", "api", "main.go"), []byte("package main"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd", "worker", "main.go"), []byte("package main"), 0644))
+
+		cfg := RootCmdConfig{
+			Folder:    dir,
+			Hotreload: false,
+		}
+
+		_, err := FindRootCmdAsString(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple Go entrypoints")
+		assert.Contains(t, err.Error(), "cmd/api/main.go")
+		assert.Contains(t, err.Error(), "cmd/worker/main.go")
+	})
+
+	t.Run("uses explicit go entrypoint before auto detection", func(t *testing.T) {
+		dir := filepath.Join(tempDir, "go_explicit")
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "api"), 0755))
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "worker"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/dummy"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd", "api", "main.go"), []byte("package main"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd", "worker", "main.go"), []byte("package main"), 0644))
+
+		cfg := RootCmdConfig{
+			Folder:    dir,
+			Hotreload: false,
+			Entrypoint: core.Entrypoints{
+				Production: "go run ./cmd/api",
+			},
+		}
+
+		cmd, err := FindRootCmdAsString(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"go", "run", "./cmd/api"}, cmd)
+	})
 }
 
 func TestGetServerEnvironmentWithSecrets(t *testing.T) {

--- a/cli/server/commands_test.go
+++ b/cli/server/commands_test.go
@@ -298,6 +298,23 @@ func TestFindRootCmdAsStringWithAutoDetection(t *testing.T) {
 		assert.Contains(t, err.Error(), "cmd/worker/main.go")
 	})
 
+	t.Run("rejects unsafe go cmd entrypoint before command construction", func(t *testing.T) {
+		dir := filepath.Join(tempDir, "go_cmd_unsafe")
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "dummy;echo pwned"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/dummy"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd", "dummy;echo pwned", "main.go"), []byte("package main"), 0644))
+
+		cfg := RootCmdConfig{
+			Folder:    dir,
+			Hotreload: false,
+		}
+
+		_, err := FindRootCmdAsString(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported Go entrypoint path")
+		assert.Contains(t, err.Error(), "cmd/dummy;echo pwned/main.go")
+	})
+
 	t.Run("uses explicit go entrypoint before auto detection", func(t *testing.T) {
 		dir := filepath.Join(tempDir, "go_explicit")
 		require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "api"), 0755))


### PR DESCRIPTION
Detects Go entrypoints under `cmd/*/main.go` so existing Go projects can run without adding a manual prod entrypoint.

- Adds `cmd/*/main.go` fallback discovery for Go serve/deploy flows.
- Keeps explicit entrypoint config as the override path and covers the selection behavior in tests.

Refs ENG-2846.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a security guard (`safeGoCmdEntrypointPattern` regex) to the Go cmd entrypoint autodetection, rejecting directory names with shell-unsafe characters and providing actionable error messages pointing users to explicit config.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit ec4875ad09f6f22061fc8b56be31a8f5aa6d4478.</sup>
<!-- /MENDRAL_SUMMARY -->