### PR TITLE
Preserve sandbox storageMb during apply

### DIFF
--- a/cli/apply.go
+++ b/cli/apply.go
@@ -496,7 +496,7 @@ func preserveExtraRuntimeFields(resourceJSON []byte) []option.RequestOption {
 		return nil
 	}
 
-	extraKeys := []string{"dockerConfig", "skipBuild", "ports"}
+	extraKeys := []string{"dockerConfig", "skipBuild", "ports", "storageMb"}
 	var opts []option.RequestOption
 	for _, key := range extraKeys {
 		if val, ok := raw.Spec.Runtime[key]; ok {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -304,6 +304,20 @@ func TestSetBodyFieldsFromJSON(t *testing.T) {
 	assert.Equal(t, 42, parent.Inner.Value)
 }
 
+func TestPreserveExtraRuntimeFieldsIncludesSandboxStorage(t *testing.T) {
+	resourceJSON := []byte(`{
+		"spec": {
+			"runtime": {
+				"storageMb": 102400
+			}
+		}
+	}`)
+
+	opts := preserveExtraRuntimeFields(resourceJSON)
+
+	assert.Len(t, opts, 1)
+}
+
 func TestApplyResourcesEmpty(t *testing.T) {
 	results := []core.Result{}
 

--- a/cli/core/config.go
+++ b/cli/core/config.go
@@ -438,6 +438,8 @@ MY_VAR = "my-value"
 # Runtime configuration (optional)
 [runtime]
 memory = 4096
+# Sandbox root storage in MB (optional)
+# storageMb = 102400
 # Job configuration (optional)
 # maxConcurrentTasks = 10
 # timeout = "15m"  # Supports: 30s, 5m, 1h, 2d, 1w or plain seconds (900)

--- a/cli/core/config_test.go
+++ b/cli/core/config_test.go
@@ -254,6 +254,7 @@ func TestGetBlaxelTomlSample(t *testing.T) {
 	assert.Contains(t, sample, "[env]")
 	assert.Contains(t, sample, "[runtime]")
 	assert.Contains(t, sample, "memory = 4096")
+	assert.Contains(t, sample, "storageMb = 102400")
 }
 
 func TestBuildBlaxelTomlWarning(t *testing.T) {

--- a/samples/sandbox-with-storage.yaml
+++ b/samples/sandbox-with-storage.yaml
@@ -1,0 +1,15 @@
+apiVersion: blaxel.ai/v1alpha1
+kind: Sandbox
+metadata:
+  name: sandbox-with-storage
+  displayName: Sandbox with Storage
+spec:
+  enabled: true
+  runtime:
+    image: blaxel/base-image:latest
+    ports:
+      - name: sandbox-api
+        target: 8080
+        protocol: HTTP
+    memory: 4096
+    storageMb: 102400


### PR DESCRIPTION
- Preserves storageMb when applying sandbox runtime config before typed SDK support lands.
- Adds storageMb to generated sandbox config samples.
- Covers runtime field preservation and sample rendering.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `storageMb` to the list of extra runtime fields preserved during sandbox apply, adds a commented-out example in the TOML sample config, a new YAML sample file, and test coverage for both.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e276c9df4cdaa7df36b1d62cb9e8a212d636031e.</sup>
<!-- /MENDRAL_SUMMARY -->