### PR TITLE
feat: add GitHub Runner job template choice

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -442,6 +442,10 @@ func TestNewCmd(t *testing.T) {
 	yesFlag := cmd.Flags().Lookup("yes")
 	assert.NotNil(t, yesFlag)
 	assert.Equal(t, "y", yesFlag.Shorthand)
+	assert.Contains(t, yesFlag.Usage, "job creation also requires --template")
+
+	assert.Contains(t, cmd.Long, "GitHub Actions runners")
+	assert.Contains(t, cmd.Example, "bl new job my-github-runner -t github-runner -y")
 }
 
 func TestParseNewType(t *testing.T) {

--- a/cli/core/create.go
+++ b/cli/core/create.go
@@ -119,6 +119,12 @@ func runCreateFlowWithDeps(
 ) error {
 	deps = fillCreateFlowDeps(deps)
 
+	if cfg.NoTTY && cfg.TemplateType == "job" && templateNameFlag == "" {
+		createErr := fmt.Errorf("--template is required when using --yes for job creation; run 'bl new job --list' to see available templates")
+		PrintError(cfg.ErrorPrefix, createErr)
+		return createErr
+	}
+
 	if templateNameFlag != "" {
 		templateNameFlag = normalizeTemplateNameFlag(templateNameFlag, cfg.TemplateType)
 	}
@@ -186,6 +192,13 @@ func runCreateFlowWithDeps(
 		}
 	}
 
+	if cfg.TemplateType == "job" {
+		if err := validateJobTemplateOptions(opts); err != nil {
+			PrintError(cfg.ErrorPrefix, err)
+			return err
+		}
+	}
+
 	// Clone template using the unified helper
 	if err := deps.CloneTemplate(opts, templates, cfg.NoTTY, cfg.ErrorPrefix, cfg.SpinnerTitle); err != nil {
 		return err
@@ -246,7 +259,11 @@ func normalizeTemplateNameFlag(templateNameFlag string, templateType string) str
 }
 
 func templateDisplayName(t Template) string {
-	return regexp.MustCompile(`^\d+-`).ReplaceAllString(t.Name, "")
+	return canonicalTemplateName(t.Name)
+}
+
+func canonicalTemplateName(name string) string {
+	return regexp.MustCompile(`^\d+-`).ReplaceAllString(name, "")
 }
 
 func printAvailableTemplates(templates Templates, templateType string) {
@@ -254,6 +271,12 @@ func printAvailableTemplates(templates Templates, templateType string) {
 	if templateType == "sandbox" {
 		for _, t := range sandboxTemplatesForDisplay(templates) {
 			printSandboxTemplateLine(t)
+		}
+		return
+	}
+	if templateType == "job" {
+		for _, t := range jobTemplatesForDisplay(templates) {
+			printJobTemplateLine(t)
 		}
 		return
 	}
@@ -295,6 +318,22 @@ func printTemplateLine(t Template) {
 // directory is empty.
 // resource is used in messages, e.g. "agent app", "job", "mcp server".
 func PromptTemplateOptions(directory string, templates Templates, resource string, includeLanguage bool, templateHeight int) TemplateOptions {
+	return promptTemplateOptions(directory, templates, resource, includeLanguage, templateHeight, templateOptionLabel)
+}
+
+func templateOptionLabel(t Template) string {
+	key := canonicalTemplateName(t.Name)
+	return strings.TrimPrefix(key, "template-")
+}
+
+func promptTemplateOptions(
+	directory string,
+	templates Templates,
+	resource string,
+	includeLanguage bool,
+	templateHeight int,
+	optionLabel func(Template) string,
+) TemplateOptions {
 	options := TemplateOptions{
 		ProjectName:  directory,
 		Directory:    directory,
@@ -308,9 +347,8 @@ func PromptTemplateOptions(directory string, templates Templates, resource strin
 		options.Author = "blaxel"
 	}
 
-	stripRe := regexp.MustCompile(`^\d+-`)
 	isBlank := func(t Template) bool {
-		name := strings.ToLower(stripRe.ReplaceAllString(t.Name, ""))
+		name := strings.ToLower(canonicalTemplateName(t.Name))
 		return strings.Contains(name, "template-blank") || strings.HasPrefix(name, "blank-") || name == "blank"
 	}
 
@@ -428,9 +466,7 @@ func PromptTemplateOptions(directory string, templates Templates, resource strin
 				if isBlank(t) {
 					continue
 				}
-				key := stripRe.ReplaceAllString(t.Name, "")
-				key = strings.TrimPrefix(key, "template-")
-				templateOptions = append(templateOptions, huh.NewOption(key, t.Name))
+				templateOptions = append(templateOptions, huh.NewOption(optionLabel(t), t.Name))
 			}
 		}).
 		Run()
@@ -515,14 +551,10 @@ func RunJobCreation(dirArg string, templateName string, noTTY bool) {
 			SpinnerTitle: "Creating your blaxel job...",
 		},
 		func(directory string, templates Templates) TemplateOptions {
-			return PromptTemplateOptions(directory, templates, "job", true, 5)
+			return PromptJobTemplateOptions(directory, templates)
 		},
 		func(opts TemplateOptions) {
-			PrintSuccess("Your blaxel job has been created successfully!")
-			fmt.Printf(`Start working on it:
-  cd %s
-  bl run job %s --local --file batches/sample-batch.json
-`, opts.Directory, opts.Directory)
+			printJobCreationSuccess(opts)
 		},
 	)
 }

--- a/cli/core/create_test.go
+++ b/cli/core/create_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	blaxel "github.com/blaxel-ai/sdk-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestGenerateRandomDirectoryName(t *testing.T) {
@@ -209,6 +211,302 @@ func TestRunCreateFlowWithDepsReturnsErrorWhenTemplateNotFound(t *testing.T) {
 	assert.Contains(t, stderr, "google-adk-py")
 }
 
+func TestRunCreateFlowWithDepsRequiresJobTemplateWithYes(t *testing.T) {
+	var runErr error
+	stdout, stderr := captureStandardStreams(t, func() {
+		runErr = runCreateFlowWithDeps(
+			filepath.Join(t.TempDir(), "new-job"),
+			"",
+			CreateFlowConfig{
+				TemplateType: "job",
+				NoTTY:        true,
+				ErrorPrefix:  "Job creation",
+				SpinnerTitle: "Creating your blaxel job...",
+			},
+			func(directory string, templates Templates) TemplateOptions {
+				t.Fatal("prompt should not run in non-interactive job creation")
+				return TemplateOptions{}
+			},
+			func(opts TemplateOptions) {
+				t.Fatal("success should not run without an explicit template")
+			},
+			createFlowDeps{
+				RetrieveTemplates: func(templateType string, noTTY bool, errorPrefix string) (Templates, error) {
+					t.Fatal("catalog retrieval should not run without an explicit template")
+					return nil, nil
+				},
+				CloneTemplate: func(opts TemplateOptions, templates Templates, noTTY bool, errorPrefix string, spinnerTitle string) error {
+					t.Fatal("clone should not run without an explicit template")
+					return nil
+				},
+			},
+		)
+	})
+
+	require.Error(t, runErr)
+	assert.Contains(t, runErr.Error(), "--template is required")
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "bl new job --list")
+}
+
+func TestRunCreateFlowWithDepsValidatesJobTemplateBeforeDirectory(t *testing.T) {
+	existingDirectory := t.TempDir()
+	err := runCreateFlowWithDeps(
+		existingDirectory,
+		"",
+		CreateFlowConfig{TemplateType: "job", NoTTY: true, ErrorPrefix: "Job creation"},
+		func(directory string, templates Templates) TemplateOptions {
+			t.Fatal("prompt should not run in non-interactive job creation")
+			return TemplateOptions{}
+		},
+		func(opts TemplateOptions) {
+			t.Fatal("success should not run without an explicit template")
+		},
+		createFlowDeps{
+			RetrieveTemplates: func(templateType string, noTTY bool, errorPrefix string) (Templates, error) {
+				t.Fatal("catalog retrieval should not run without an explicit template")
+				return nil, nil
+			},
+		},
+	)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "--template is required")
+	assert.NotContains(t, err.Error(), "already exists")
+}
+
+func TestRunCreateFlowWithDepsReturnsErrorWhenGithubRunnerIsUnavailable(t *testing.T) {
+	cloneCalled := false
+	cleanCalled := false
+	successCalled := false
+	var runErr error
+	stdout, stderr := captureStandardStreams(t, func() {
+		runErr = runCreateFlowWithDeps(
+			filepath.Join(t.TempDir(), "new-runner"),
+			"github-runner",
+			CreateFlowConfig{
+				TemplateType: "job",
+				NoTTY:        true,
+				ErrorPrefix:  "Job creation",
+			},
+			func(directory string, templates Templates) TemplateOptions {
+				t.Fatal("prompt should not run when a template flag is provided")
+				return TemplateOptions{}
+			},
+			func(opts TemplateOptions) {
+				successCalled = true
+			},
+			createFlowDeps{
+				RetrieveTemplates: func(templateType string, noTTY bool, errorPrefix string) (Templates, error) {
+					return testJobTemplates(false, ""), nil
+				},
+				CloneTemplate: func(opts TemplateOptions, templates Templates, noTTY bool, errorPrefix string, spinnerTitle string) error {
+					cloneCalled = true
+					return nil
+				},
+				CleanTemplate: func(directory string) {
+					cleanCalled = true
+				},
+			},
+		)
+	})
+
+	require.Error(t, runErr)
+	assert.ErrorContains(t, runErr, "template 'template-github-runner' not found")
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "jobs-ts")
+	assert.Contains(t, stderr, "jobs-py")
+	assert.NotContains(t, stderr, "  - github-runner")
+	assert.False(t, cloneCalled)
+	assert.False(t, cleanCalled)
+	assert.False(t, successCalled)
+}
+
+func TestRunCreateFlowWithDepsResolvesJobTemplateAliases(t *testing.T) {
+	tests := []struct {
+		name             string
+		templateFlag     string
+		expectedTemplate string
+		expectedLanguage string
+	}{
+		{name: "python blank", templateFlag: "jobs-py", expectedTemplate: jobPythonTemplate, expectedLanguage: "python"},
+		{name: "typescript blank", templateFlag: "jobs-ts", expectedTemplate: jobTypescriptTemplate, expectedLanguage: "typescript"},
+		{name: "github runner", templateFlag: "github-runner", expectedTemplate: jobGithubRunnerTemplate},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			directory := filepath.Join(t.TempDir(), "new-job")
+			var clonedOpts TemplateOptions
+			var successOpts TemplateOptions
+			err := runCreateFlowWithDeps(
+				directory,
+				tt.templateFlag,
+				CreateFlowConfig{TemplateType: "job", NoTTY: true, ErrorPrefix: "Job creation"},
+				func(directory string, templates Templates) TemplateOptions {
+					t.Fatal("prompt should not run when a template flag is provided")
+					return TemplateOptions{}
+				},
+				func(opts TemplateOptions) {
+					successOpts = opts
+				},
+				createFlowDeps{
+					RetrieveTemplates: func(templateType string, noTTY bool, errorPrefix string) (Templates, error) {
+						return testJobTemplates(true, ""), nil
+					},
+					CloneTemplate: func(opts TemplateOptions, templates Templates, noTTY bool, errorPrefix string, spinnerTitle string) error {
+						clonedOpts = opts
+						return nil
+					},
+					CleanTemplate: func(directory string) {},
+					OutputFormat:  func() string { return "pretty" },
+				},
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedTemplate, clonedOpts.TemplateName)
+			assert.Equal(t, tt.expectedLanguage, clonedOpts.Language)
+			assert.Equal(t, directory, clonedOpts.Directory)
+			assert.Equal(t, clonedOpts, successOpts)
+		})
+	}
+}
+
+func TestRunCreateFlowWithDepsRejectsInvalidJobLanguageMetadata(t *testing.T) {
+	tests := []struct {
+		name         string
+		templateFlag string
+		templates    Templates
+		wantError    string
+	}{
+		{
+			name:         "runner language",
+			templateFlag: "github-runner",
+			templates:    testJobTemplates(true, "python"),
+			wantError:    "must not declare a language",
+		},
+		{
+			name:         "numeric runner language",
+			templateFlag: "github-runner",
+			templates: Templates{
+				{Template: blaxel.Template{Name: "1-" + jobGithubRunnerTemplate}, Language: "python", Type: "job"},
+			},
+			wantError: "must not declare a language",
+		},
+		{
+			name:         "python blank mislabeled",
+			templateFlag: "jobs-py",
+			templates: Templates{
+				{Template: blaxel.Template{Name: jobPythonTemplate}, Language: "typescript", Type: "job"},
+			},
+			wantError: "must declare language",
+		},
+		{
+			name:         "typescript blank missing language",
+			templateFlag: "jobs-ts",
+			templates: Templates{
+				{Template: blaxel.Template{Name: jobTypescriptTemplate}, Type: "job"},
+			},
+			wantError: "must declare language",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cloneCalled := false
+			err := runCreateFlowWithDeps(
+				filepath.Join(t.TempDir(), "new-job"),
+				tt.templateFlag,
+				CreateFlowConfig{TemplateType: "job", NoTTY: true, ErrorPrefix: "Job creation"},
+				func(directory string, templates Templates) TemplateOptions {
+					t.Fatal("prompt should not run when a template flag is provided")
+					return TemplateOptions{}
+				},
+				func(opts TemplateOptions) {
+					t.Fatal("success should not run for invalid job metadata")
+				},
+				createFlowDeps{
+					RetrieveTemplates: func(templateType string, noTTY bool, errorPrefix string) (Templates, error) {
+						return tt.templates, nil
+					},
+					CloneTemplate: func(opts TemplateOptions, templates Templates, noTTY bool, errorPrefix string, spinnerTitle string) error {
+						cloneCalled = true
+						return nil
+					},
+				},
+			)
+
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.wantError)
+			assert.False(t, cloneCalled)
+		})
+	}
+}
+
+func TestRunCreateFlowWithDepsPrintsStructuredJobOutput(t *testing.T) {
+	tests := []struct {
+		name         string
+		format       string
+		templateFlag string
+		templateName string
+		language     string
+	}{
+		{name: "runner json", format: "json", templateFlag: "github-runner", templateName: jobGithubRunnerTemplate},
+		{name: "blank json", format: "json", templateFlag: "jobs-py", templateName: jobPythonTemplate, language: "python"},
+		{name: "runner yaml", format: "yaml", templateFlag: "github-runner", templateName: jobGithubRunnerTemplate},
+		{name: "blank yaml", format: "yaml", templateFlag: "jobs-ts", templateName: jobTypescriptTemplate, language: "typescript"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			directory := filepath.Join(t.TempDir(), "new-job")
+			successCalled := false
+			var runErr error
+			stdout, stderr := captureStandardStreams(t, func() {
+				runErr = runCreateFlowWithDeps(
+					directory,
+					tt.templateFlag,
+					CreateFlowConfig{TemplateType: "job", NoTTY: true, ErrorPrefix: "Job creation"},
+					func(directory string, templates Templates) TemplateOptions {
+						t.Fatal("prompt should not run when a template flag is provided")
+						return TemplateOptions{}
+					},
+					func(opts TemplateOptions) {
+						successCalled = true
+					},
+					createFlowDeps{
+						RetrieveTemplates: func(templateType string, noTTY bool, errorPrefix string) (Templates, error) {
+							return testJobTemplates(true, ""), nil
+						},
+						CloneTemplate: func(opts TemplateOptions, templates Templates, noTTY bool, errorPrefix string, spinnerTitle string) error {
+							return nil
+						},
+						CleanTemplate: func(directory string) {},
+						OutputFormat:  func() string { return tt.format },
+					},
+				)
+			})
+
+			require.NoError(t, runErr)
+			assert.Empty(t, stderr)
+			assert.False(t, successCalled)
+
+			result := map[string]string{}
+			if tt.format == "json" {
+				require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+			} else {
+				require.NoError(t, yaml.Unmarshal([]byte(stdout), &result))
+			}
+			assert.Equal(t, map[string]string{
+				"directory": directory,
+				"template":  tt.templateName,
+				"language":  tt.language,
+				"type":      "job",
+			}, result)
+		})
+	}
+}
+
 func TestRunCreateFlowWithDepsReturnsCloneFailure(t *testing.T) {
 	cloneErr := errors.New("dependency install failed")
 	cleanCalled := false
@@ -266,6 +564,12 @@ func TestNormalizeTemplateNameFlag(t *testing.T) {
 			templateType: "agent",
 			input:        "template-google-adk-py",
 			expected:     "template-google-adk-py",
+		},
+		{
+			name:         "maps github runner job shorthand",
+			templateType: "job",
+			input:        "github-runner",
+			expected:     jobGithubRunnerTemplate,
 		},
 		{
 			name:         "prefixes non-sandbox shorthand",

--- a/cli/core/job_templates.go
+++ b/cli/core/job_templates.go
@@ -1,0 +1,232 @@
+package core
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"unicode"
+
+	"github.com/charmbracelet/huh"
+)
+
+const (
+	jobPythonTemplate       = "template-jobs-py"
+	jobTypescriptTemplate   = "template-jobs-ts"
+	jobGithubRunnerTemplate = "template-github-runner"
+	jobBlankChoice          = "blank"
+	jobGithubRunnerChoice   = "github-runner"
+)
+
+type jobTemplateChoice struct {
+	label string
+	value string
+}
+
+type jobTemplatePromptDeps struct {
+	selectJobType   func(directory string, choices []jobTemplateChoice) (string, string, error)
+	promptTemplates func(directory string, templates Templates) TemplateOptions
+}
+
+func findJobTemplate(templates Templates, canonicalName string) (Template, bool) {
+	for _, template := range templates {
+		if canonicalTemplateName(template.Name) == canonicalName {
+			return template, true
+		}
+	}
+	return Template{}, false
+}
+
+func blankJobTemplates(templates Templates) Templates {
+	blank := Templates{}
+	for _, template := range templates {
+		name := canonicalTemplateName(template.Name)
+		if name == jobPythonTemplate || name == jobTypescriptTemplate {
+			blank = append(blank, template)
+		}
+	}
+	return blank
+}
+
+func jobTemplateChoices(templates Templates) []jobTemplateChoice {
+	choices := []jobTemplateChoice{}
+	if len(blankJobTemplates(templates)) > 0 {
+		choices = append(choices, jobTemplateChoice{label: "Blank", value: jobBlankChoice})
+	}
+	if _, ok := findJobTemplate(templates, jobGithubRunnerTemplate); ok {
+		choices = append(choices, jobTemplateChoice{label: "GitHub Runner", value: jobGithubRunnerChoice})
+	}
+	return choices
+}
+
+func jobTemplatesForDisplay(templates Templates) Templates {
+	ordered := blankJobTemplates(templates)
+	seen := map[string]bool{}
+	for _, template := range ordered {
+		seen[template.Name] = true
+	}
+
+	if runner, ok := findJobTemplate(templates, jobGithubRunnerTemplate); ok {
+		ordered = append(ordered, runner)
+		seen[runner.Name] = true
+	}
+
+	for _, template := range templates {
+		if !seen[template.Name] {
+			ordered = append(ordered, template)
+		}
+	}
+	return ordered
+}
+
+func validateJobTemplateOptions(opts TemplateOptions) error {
+	switch canonicalTemplateName(opts.TemplateName) {
+	case jobGithubRunnerTemplate:
+		if opts.Language != "" {
+			return fmt.Errorf("github runner template must not declare a language, got %q", opts.Language)
+		}
+	case jobPythonTemplate:
+		if opts.Language != "python" {
+			return fmt.Errorf("python job template must declare language %q, got %q", "python", opts.Language)
+		}
+	case jobTypescriptTemplate:
+		if opts.Language != "typescript" {
+			return fmt.Errorf("typescript job template must declare language %q, got %q", "typescript", opts.Language)
+		}
+	}
+	return nil
+}
+
+func PromptJobTemplateOptions(directory string, templates Templates) TemplateOptions {
+	opts, err := promptJobTemplateOptionsWithDeps(directory, templates, jobTemplatePromptDeps{
+		selectJobType: selectJobType,
+		promptTemplates: func(directory string, templates Templates) TemplateOptions {
+			return promptTemplateOptions(directory, templates, "job", true, 5, jobTemplateOptionLabel)
+		},
+	})
+	if err != nil {
+		os.Exit(0)
+	}
+	return opts
+}
+
+func promptJobTemplateOptionsWithDeps(directory string, templates Templates, deps jobTemplatePromptDeps) (TemplateOptions, error) {
+	choices := jobTemplateChoices(templates)
+	if len(choices) == 0 {
+		return deps.promptTemplates(directory, templates), nil
+	}
+	if len(choices) == 1 {
+		if choices[0].value == jobBlankChoice {
+			return deps.promptTemplates(directory, blankJobTemplates(templates)), nil
+		}
+		return CreateDefaultTemplateOptions(directory, jobGithubRunnerTemplate, templates), nil
+	}
+
+	selectedType, selectedDirectory, err := deps.selectJobType(directory, choices)
+	if err != nil {
+		return TemplateOptions{}, err
+	}
+	if selectedType == jobBlankChoice {
+		return deps.promptTemplates(selectedDirectory, blankJobTemplates(templates)), nil
+	}
+	if selectedType == jobGithubRunnerChoice {
+		return CreateDefaultTemplateOptions(selectedDirectory, jobGithubRunnerTemplate, templates), nil
+	}
+	return TemplateOptions{}, fmt.Errorf("unknown job type %q", selectedType)
+}
+
+func selectJobType(directory string, choices []jobTemplateChoice) (string, string, error) {
+	selectedType := choices[0].value
+	fields := []huh.Field{}
+	if directory == "" {
+		fields = append(fields, huh.NewInput().
+			Title("Name").
+			Description("Name of your job").
+			Value(&directory),
+		)
+	}
+
+	typeOptions := make([]huh.Option[string], 0, len(choices))
+	for _, choice := range choices {
+		typeOptions = append(typeOptions, huh.NewOption(choice.label, choice.value))
+	}
+	fields = append(fields, huh.NewSelect[string]().
+		Title("Job type").
+		Description("Choose the job to scaffold.").
+		Options(typeOptions...).
+		Value(&selectedType),
+	)
+
+	form := huh.NewForm(huh.NewGroup(fields...))
+	form.WithTheme(GetHuhTheme())
+	if err := form.Run(); err != nil {
+		return "", directory, err
+	}
+	return selectedType, directory, nil
+}
+
+func sanitizeJobTerminalText(value string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) || isBidiControl(r) {
+			return ' '
+		}
+		return r
+	}, value)
+}
+
+func isBidiControl(r rune) bool {
+	return r == '\u061c' || r == '\u200e' || r == '\u200f' ||
+		(r >= '\u202a' && r <= '\u202e') ||
+		(r >= '\u2066' && r <= '\u2069')
+}
+
+func printJobTemplateLine(t Template) {
+	name := sanitizeJobTerminalText(strings.TrimPrefix(templateDisplayName(t), "template-"))
+	description := sanitizeJobTerminalText(t.Description)
+	if description != "" {
+		PrintDiagnostic(fmt.Sprintf("  - %-30s %s", name, description))
+		return
+	}
+	PrintDiagnostic(fmt.Sprintf("  - %s", name))
+}
+
+func jobTemplateOptionLabel(t Template) string {
+	return sanitizeJobTerminalText(templateOptionLabel(t))
+}
+
+func isPortableJobName(value string) bool {
+	if value == "" || strings.HasPrefix(value, "-") {
+		return false
+	}
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || strings.ContainsRune("._-", r) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func printJobCreationSuccess(opts TemplateOptions) {
+	PrintSuccess("Your blaxel job has been created successfully!")
+	changeDirectory := "  Open the created project directory."
+	runJob := "  Run the sample locally with your job name:\n    bl run job JOB_NAME --local --file batches/sample-batch.json"
+	if isPortableJobName(opts.Directory) {
+		changeDirectory = "  cd " + opts.Directory
+		runJob = "  bl run job " + opts.Directory + " --local --file batches/sample-batch.json"
+	}
+	if canonicalTemplateName(opts.TemplateName) == jobGithubRunnerTemplate {
+		fmt.Printf(`Configure your GitHub Runner:
+%s
+  1. Set the allowed owner/repo values in [githubRunner] in blaxel.toml
+  2. Run bl deploy
+  3. Install the Blaxel GitHub App from the job settings in the Blaxel console
+  4. Run bl deploy --skip-build
+`, changeDirectory)
+		return
+	}
+
+	fmt.Printf(`Start working on it:
+%s
+%s
+`, changeDirectory, runJob)
+}

--- a/cli/core/job_templates.go
+++ b/cli/core/job_templates.go
@@ -217,10 +217,8 @@ func printJobCreationSuccess(opts TemplateOptions) {
 	if canonicalTemplateName(opts.TemplateName) == jobGithubRunnerTemplate {
 		fmt.Printf(`Configure your GitHub Runner:
 %s
-  1. Set the allowed owner/repo values in [githubRunner] in blaxel.toml
-  2. Run bl deploy
-  3. Install the Blaxel GitHub App from the job settings in the Blaxel console
-  4. Run bl deploy --skip-build
+  1. Run bl deploy
+  2. Add your repository from the GitHub Runner settings in the Blaxel console
 `, changeDirectory)
 		return
 	}

--- a/cli/core/job_templates_test.go
+++ b/cli/core/job_templates_test.go
@@ -1,0 +1,310 @@
+package core
+
+import (
+	"strings"
+	"testing"
+
+	blaxel "github.com/blaxel-ai/sdk-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func testJobTemplates(includeRunner bool, runnerLanguage string) Templates {
+	templates := Templates{
+		{Template: blaxel.Template{Name: jobTypescriptTemplate}, Language: "typescript", Type: "job"},
+		{Template: blaxel.Template{Name: jobPythonTemplate}, Language: "python", Type: "job"},
+	}
+	if includeRunner {
+		templates = append(templates, Template{
+			Template: blaxel.Template{Name: jobGithubRunnerTemplate},
+			Language: runnerLanguage,
+			Type:     "job",
+		})
+	}
+	return templates
+}
+
+func templateNames(templates Templates) []string {
+	names := make([]string, 0, len(templates))
+	for _, template := range templates {
+		names = append(names, template.Name)
+	}
+	return names
+}
+
+func TestJobTemplateChoices(t *testing.T) {
+	templates := testJobTemplates(true, "")
+
+	assert.Equal(t, []jobTemplateChoice{
+		{label: "Blank", value: jobBlankChoice},
+		{label: "GitHub Runner", value: jobGithubRunnerChoice},
+	}, jobTemplateChoices(templates))
+}
+
+func TestJobTemplateChoicesRequireCatalogEntries(t *testing.T) {
+	t.Run("runner is hidden until it is in the catalog", func(t *testing.T) {
+		templates := Templates{
+			{Template: blaxel.Template{Name: jobPythonTemplate}, Language: "python", Type: "job"},
+		}
+
+		assert.Equal(t, []jobTemplateChoice{
+			{label: "Blank", value: jobBlankChoice},
+		}, jobTemplateChoices(templates))
+	})
+
+	t.Run("blank is hidden without a known blank template", func(t *testing.T) {
+		templates := Templates{
+			{Template: blaxel.Template{Name: jobGithubRunnerTemplate}, Type: "job"},
+		}
+
+		assert.Equal(t, []jobTemplateChoice{
+			{label: "GitHub Runner", value: jobGithubRunnerChoice},
+		}, jobTemplateChoices(templates))
+	})
+}
+
+func TestPromptJobTemplateOptionsWithDeps(t *testing.T) {
+	templates := testJobTemplates(true, "")
+
+	t.Run("blank delegates to the existing language picker", func(t *testing.T) {
+		expected := TemplateOptions{Directory: "selected-dir", TemplateName: jobPythonTemplate, Language: "python"}
+		opts, err := promptJobTemplateOptionsWithDeps("initial-dir", templates, jobTemplatePromptDeps{
+			selectJobType: func(directory string, choices []jobTemplateChoice) (string, string, error) {
+				assert.Equal(t, "initial-dir", directory)
+				assert.Len(t, choices, 2)
+				return jobBlankChoice, "selected-dir", nil
+			},
+			promptTemplates: func(directory string, templates Templates) TemplateOptions {
+				assert.Equal(t, "selected-dir", directory)
+				assert.Equal(t, []string{jobTypescriptTemplate, jobPythonTemplate}, templateNames(templates))
+				return expected
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, opts)
+	})
+
+	t.Run("runner skips the language picker", func(t *testing.T) {
+		opts, err := promptJobTemplateOptionsWithDeps("runner-dir", templates, jobTemplatePromptDeps{
+			selectJobType: func(directory string, choices []jobTemplateChoice) (string, string, error) {
+				return jobGithubRunnerChoice, directory, nil
+			},
+			promptTemplates: func(directory string, templates Templates) TemplateOptions {
+				t.Fatal("blank picker should not run for GitHub Runner")
+				return TemplateOptions{}
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, "runner-dir", opts.Directory)
+		assert.Equal(t, jobGithubRunnerTemplate, opts.TemplateName)
+		assert.Empty(t, opts.Language)
+	})
+
+	t.Run("python-only catalog keeps the existing picker", func(t *testing.T) {
+		pythonOnly := Templates{{Template: blaxel.Template{Name: jobPythonTemplate}, Language: "python", Type: "job"}}
+		expected := TemplateOptions{Directory: "python-dir", TemplateName: jobPythonTemplate, Language: "python"}
+		opts, err := promptJobTemplateOptionsWithDeps("python-dir", pythonOnly, jobTemplatePromptDeps{
+			selectJobType: func(directory string, choices []jobTemplateChoice) (string, string, error) {
+				t.Fatal("job type picker should not run with only Blank available")
+				return "", "", nil
+			},
+			promptTemplates: func(directory string, templates Templates) TemplateOptions {
+				assert.Equal(t, []string{jobPythonTemplate}, templateNames(templates))
+				return expected
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, opts)
+	})
+
+	t.Run("runner-only catalog auto-selects runner", func(t *testing.T) {
+		runnerOnly := Templates{{Template: blaxel.Template{Name: jobGithubRunnerTemplate}, Type: "job"}}
+		opts, err := promptJobTemplateOptionsWithDeps("runner-dir", runnerOnly, jobTemplatePromptDeps{
+			selectJobType: func(directory string, choices []jobTemplateChoice) (string, string, error) {
+				t.Fatal("job type picker should not run with only GitHub Runner available")
+				return "", "", nil
+			},
+			promptTemplates: func(directory string, templates Templates) TemplateOptions {
+				t.Fatal("blank picker should not run with only GitHub Runner available")
+				return TemplateOptions{}
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, jobGithubRunnerTemplate, opts.TemplateName)
+	})
+
+	t.Run("custom-only catalog delegates to the generic picker", func(t *testing.T) {
+		customTemplates := Templates{
+			{Template: blaxel.Template{Name: "template-custom-one"}, Type: "job"},
+			{Template: blaxel.Template{Name: "template-custom-two"}, Type: "job"},
+		}
+		expected := TemplateOptions{Directory: "custom-dir", TemplateName: "template-custom-two"}
+		opts, err := promptJobTemplateOptionsWithDeps("custom-dir", customTemplates, jobTemplatePromptDeps{
+			selectJobType: func(directory string, choices []jobTemplateChoice) (string, string, error) {
+				t.Fatal("job type picker should not run without known job types")
+				return "", "", nil
+			},
+			promptTemplates: func(directory string, templates Templates) TemplateOptions {
+				assert.Equal(t, "custom-dir", directory)
+				assert.Equal(t, templateNames(customTemplates), templateNames(templates))
+				return expected
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, opts)
+	})
+}
+
+func TestValidateJobTemplateOptions(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      TemplateOptions
+		wantError string
+	}{
+		{name: "runner", opts: TemplateOptions{TemplateName: jobGithubRunnerTemplate}},
+		{name: "numeric runner", opts: TemplateOptions{TemplateName: "1-" + jobGithubRunnerTemplate}},
+		{name: "runner with language", opts: TemplateOptions{TemplateName: jobGithubRunnerTemplate, Language: "python"}, wantError: "must not declare a language"},
+		{name: "numeric runner with language", opts: TemplateOptions{TemplateName: "1-" + jobGithubRunnerTemplate, Language: "python"}, wantError: "must not declare a language"},
+		{name: "python", opts: TemplateOptions{TemplateName: jobPythonTemplate, Language: "python"}},
+		{name: "python mislabeled", opts: TemplateOptions{TemplateName: jobPythonTemplate, Language: "typescript"}, wantError: "must declare language"},
+		{name: "typescript", opts: TemplateOptions{TemplateName: jobTypescriptTemplate, Language: "typescript"}},
+		{name: "typescript missing language", opts: TemplateOptions{TemplateName: jobTypescriptTemplate}, wantError: "must declare language"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateJobTemplateOptions(tt.opts)
+			if tt.wantError != "" {
+				assert.ErrorContains(t, err, tt.wantError)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestJobTemplatesForDisplay(t *testing.T) {
+	t.Run("orders known templates before custom templates", func(t *testing.T) {
+		templates := Templates{
+			{Template: blaxel.Template{Name: jobGithubRunnerTemplate}, Type: "job"},
+			{Template: blaxel.Template{Name: "template-custom-job"}, Type: "job"},
+			{Template: blaxel.Template{Name: jobTypescriptTemplate}, Language: "typescript", Type: "job"},
+			{Template: blaxel.Template{Name: jobPythonTemplate}, Language: "python", Type: "job"},
+		}
+
+		assert.Equal(t, []string{
+			jobTypescriptTemplate,
+			jobPythonTemplate,
+			jobGithubRunnerTemplate,
+			"template-custom-job",
+		}, templateNames(jobTemplatesForDisplay(templates)))
+	})
+
+	t.Run("preserves available templates when runner is absent", func(t *testing.T) {
+		assert.Equal(t, []string{
+			jobTypescriptTemplate,
+			jobPythonTemplate,
+		}, templateNames(jobTemplatesForDisplay(testJobTemplates(false, ""))))
+	})
+
+	t.Run("preserves runner when blank is absent", func(t *testing.T) {
+		templates := Templates{{Template: blaxel.Template{Name: jobGithubRunnerTemplate}, Type: "job"}}
+		assert.Equal(t, []string{jobGithubRunnerTemplate}, templateNames(jobTemplatesForDisplay(templates)))
+	})
+}
+
+func TestIsPortableJobName(t *testing.T) {
+	assert.True(t, isPortableJobName("my-job_2"))
+	assert.False(t, isPortableJobName("projects/my-job"))
+	assert.False(t, isPortableJobName("-leading-dash"))
+	assert.False(t, isPortableJobName("path with spaces"))
+	assert.False(t, isPortableJobName("$(unsafe)"))
+	assert.False(t, isPortableJobName("line\nbreak"))
+}
+
+func TestJobTemplateOptionLabelSanitizesFallbackCatalogNames(t *testing.T) {
+	template := Template{Template: blaxel.Template{Name: "template-bad\nname\u202e"}, Type: "job"}
+	label := jobTemplateOptionLabel(template)
+
+	assert.Equal(t, "bad name ", label)
+	assert.NotContains(t, label, "\n")
+	assert.NotContains(t, label, "\u202e")
+}
+
+func TestPrintAvailableJobTemplatesSanitizesCatalogText(t *testing.T) {
+	templates := Templates{{
+		Template: blaxel.Template{
+			Name:        "template-bad\nname\u202e",
+			Description: "unsafe\x1b]0;title\a description\u2066",
+		},
+		Type: "job",
+	}}
+
+	stdout, stderr := captureStandardStreams(t, func() {
+		printAvailableTemplates(templates, "job")
+	})
+
+	assert.Empty(t, stdout)
+	assert.NotContains(t, stderr, "\nname")
+	assert.NotContains(t, stderr, "\x1b")
+	assert.NotContains(t, stderr, "\a")
+	assert.NotContains(t, stderr, "\u202e")
+	assert.NotContains(t, stderr, "\u2066")
+	assert.Contains(t, stderr, "bad name")
+	assert.Contains(t, stderr, "unsafe ]0;title  description")
+}
+
+func TestPrintJobCreationSuccess(t *testing.T) {
+	t.Run("blank job keeps batch instructions", func(t *testing.T) {
+		stdout, stderr := captureStandardStreams(t, func() {
+			printJobCreationSuccess(TemplateOptions{
+				Directory:    "my-job",
+				TemplateName: jobPythonTemplate,
+			})
+		})
+
+		assert.Empty(t, stderr)
+		assert.Contains(t, stdout, "Your blaxel job has been created successfully")
+		assert.Contains(t, stdout, "cd my-job")
+		assert.Contains(t, stdout, "bl run job my-job --local --file batches/sample-batch.json")
+		assert.NotContains(t, stdout, "GitHub App")
+	})
+
+	t.Run("unsafe directory avoids shell interpolation", func(t *testing.T) {
+		stdout, stderr := captureStandardStreams(t, func() {
+			printJobCreationSuccess(TemplateOptions{
+				Directory:    "$(unsafe path)",
+				TemplateName: jobPythonTemplate,
+			})
+		})
+
+		assert.Empty(t, stderr)
+		assert.NotContains(t, stdout, "$(unsafe path)")
+		assert.Contains(t, stdout, "Open the created project directory")
+		assert.Contains(t, stdout, "bl run job JOB_NAME --local --file batches/sample-batch.json")
+	})
+
+	t.Run("github runner prints setup instructions", func(t *testing.T) {
+		stdout, stderr := captureStandardStreams(t, func() {
+			printJobCreationSuccess(TemplateOptions{
+				Directory:    "my-runner",
+				TemplateName: jobGithubRunnerTemplate,
+			})
+		})
+
+		assert.Empty(t, stderr)
+		assert.Contains(t, stdout, "Your blaxel job has been created successfully")
+		assert.Contains(t, stdout, "cd my-runner")
+		assert.Contains(t, stdout, "owner/repo")
+		assert.Contains(t, stdout, "2. Run bl deploy\n")
+		assert.Contains(t, stdout, "3. Install the Blaxel GitHub App")
+		assert.Contains(t, stdout, "4. Run bl deploy --skip-build")
+		assert.Less(t, strings.Index(stdout, "2. Run bl deploy"), strings.Index(stdout, "3. Install"))
+		assert.Less(t, strings.Index(stdout, "3. Install"), strings.Index(stdout, "4. Run bl deploy --skip-build"))
+		assert.NotContains(t, stdout, "sample-batch.json")
+	})
+}

--- a/cli/core/job_templates_test.go
+++ b/cli/core/job_templates_test.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"strings"
 	"testing"
 
 	blaxel "github.com/blaxel-ai/sdk-go"
@@ -299,12 +298,10 @@ func TestPrintJobCreationSuccess(t *testing.T) {
 		assert.Empty(t, stderr)
 		assert.Contains(t, stdout, "Your blaxel job has been created successfully")
 		assert.Contains(t, stdout, "cd my-runner")
-		assert.Contains(t, stdout, "owner/repo")
-		assert.Contains(t, stdout, "2. Run bl deploy\n")
-		assert.Contains(t, stdout, "3. Install the Blaxel GitHub App")
-		assert.Contains(t, stdout, "4. Run bl deploy --skip-build")
-		assert.Less(t, strings.Index(stdout, "2. Run bl deploy"), strings.Index(stdout, "3. Install"))
-		assert.Less(t, strings.Index(stdout, "3. Install"), strings.Index(stdout, "4. Run bl deploy --skip-build"))
+		assert.Contains(t, stdout, "1. Run bl deploy\n")
+		assert.Contains(t, stdout, "2. Add your repository from the GitHub Runner settings")
+		assert.NotContains(t, stdout, "owner/repo")
+		assert.NotContains(t, stdout, "bl deploy --skip-build")
 		assert.NotContains(t, stdout, "sample-batch.json")
 	})
 }

--- a/cli/core/templates.go
+++ b/cli/core/templates.go
@@ -303,7 +303,7 @@ func CreateDefaultTemplateOptions(directory, templateName string, templates Temp
 	// Find the template by name (supports both full name and display name)
 	var foundTemplate *Template
 	for _, template := range templates {
-		key := regexp.MustCompile(`^\d+-`).ReplaceAllString(template.Name, "")
+		key := canonicalTemplateName(template.Name)
 		if template.Name == templateName || key == templateName {
 			foundTemplate = &template
 			break

--- a/cli/deploy_integration_test.go
+++ b/cli/deploy_integration_test.go
@@ -417,6 +417,9 @@ func TestGenerateDeploymentJobIntegration(t *testing.T) {
 	tomlContent := `name = "my-job"
 type = "job"
 workspace = "test-workspace"
+
+[githubRunner]
+repositories = ["owner/repo"]
 `
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "blaxel.toml"), []byte(tomlContent), 0644))
 	require.NoError(t, os.Chdir(tempDir))
@@ -433,6 +436,9 @@ workspace = "test-workspace"
 
 	result := d.GenerateDeployment(false)
 	assert.Equal(t, "Job", result.Kind)
+	spec := result.Spec.(map[string]interface{})
+	githubRunner := spec["githubRunner"].(map[string]interface{})
+	assert.Equal(t, []interface{}{"owner/repo"}, githubRunner["repositories"])
 }
 
 // TestGenerateDeploymentSandboxIntegration tests GenerateDeployment for sandbox type

--- a/cli/new.go
+++ b/cli/new.go
@@ -63,7 +63,8 @@ Resource Types:
               Use cases: Code execution, testing, isolated workloads
 
   job       - Batch processing task that runs on-demand or on schedule
-              Use cases: ETL pipelines, data processing, scheduled workflows
+              Use cases: ETL pipelines, data processing, scheduled workflows,
+                         GitHub Actions runners
 
   volumetemplate - Pre-configured volume template for creating volumes
               		Use cases: Persistent storage templates, data volume configurations
@@ -85,9 +86,8 @@ Use --template and --yes flags for automation and CI/CD workflows.
 After Creation:
 1. cd into your new directory
 2. Review and customize the generated blaxel.toml configuration
-3. Develop your resource locally with 'bl serve --hotreload'
-4. Test it works as expected
-5. Deploy to Blaxel with 'bl deploy'`,
+3. Follow the resource-specific instructions printed after scaffolding
+4. Test the resource and deploy it when ready`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Handle --list flag
 			if listTemplates {
@@ -162,7 +162,7 @@ After Creation:
 	}
 
 	cmd.Flags().StringVarP(&templateName, "template", "t", "", "Template to use (skips interactive prompt)")
-	cmd.Flags().BoolVarP(&noTTY, "yes", "y", false, "Skip interactive prompts and use defaults")
+	cmd.Flags().BoolVarP(&noTTY, "yes", "y", false, "Skip interactive prompts (job creation also requires --template)")
 	cmd.Flags().BoolVarP(&listTemplates, "list", "l", false, "List available templates with descriptions")
 
 	cmd.Example = `  # Interactive creation (recommended for beginners)
@@ -186,6 +186,9 @@ After Creation:
 
   # Create job with specific template
   bl new job my-batch-job -t jobs-py
+
+  # Create a GitHub Actions runner job non-interactively
+  bl new job my-github-runner -t github-runner -y
 
   # List all available templates
   bl new --list

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -74,6 +74,25 @@ func TestRunCmd(t *testing.T) {
 	assert.Equal(t, "0", timeoutFlag.DefValue)
 }
 
+func TestRunCmdParsesGeneratedJobCommand(t *testing.T) {
+	cmd := RunCmd()
+	require.NoError(t, cmd.ParseFlags([]string{
+		"job",
+		"my-job",
+		"--local",
+		"--file",
+		"batches/sample-batch.json",
+	}))
+
+	assert.Equal(t, []string{"job", "my-job"}, cmd.Flags().Args())
+	local, err := cmd.Flags().GetBool("local")
+	require.NoError(t, err)
+	assert.True(t, local)
+	file, err := cmd.Flags().GetString("file")
+	require.NoError(t, err)
+	assert.Equal(t, "batches/sample-batch.json", file)
+}
+
 func TestBatchStruct(t *testing.T) {
 	batch := Batch{
 		Tasks: []map[string]interface{}{

--- a/docs/bl_new.md
+++ b/docs/bl_new.md
@@ -24,7 +24,8 @@ Resource Types:
               Use cases: Code execution, testing, isolated workloads
 
   job       - Batch processing task that runs on-demand or on schedule
-              Use cases: ETL pipelines, data processing, scheduled workflows
+              Use cases: ETL pipelines, data processing, scheduled workflows,
+                         GitHub Actions runners
 
   volumetemplate - Pre-configured volume template for creating volumes
               		Use cases: Persistent storage templates, data volume configurations
@@ -46,9 +47,8 @@ Use --template and --yes flags for automation and CI/CD workflows.
 After Creation:
 1. cd into your new directory
 2. Review and customize the generated blaxel.toml configuration
-3. Develop your resource locally with 'bl serve --hotreload'
-4. Test it works as expected
-5. Deploy to Blaxel with 'bl deploy'
+3. Follow the resource-specific instructions printed after scaffolding
+4. Test the resource and deploy it when ready
 
 ```
 bl new [type] [directory] [flags]
@@ -79,6 +79,9 @@ bl new [type] [directory] [flags]
   # Create job with specific template
   bl new job my-batch-job -t jobs-py
 
+  # Create a GitHub Actions runner job non-interactively
+  bl new job my-github-runner -t github-runner -y
+
   # List all available templates
   bl new --list
 
@@ -102,7 +105,7 @@ bl new [type] [directory] [flags]
   -h, --help              help for new
   -l, --list              List available templates with descriptions
   -t, --template string   Template to use (skips interactive prompt)
-  -y, --yes               Skip interactive prompts and use defaults
+  -y, --yes               Skip interactive prompts (job creation also requires --template)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
## Summary

- add a job-specific `Blank` versus `GitHub Runner` picker backed by the template catalog
- reuse the existing Python and TypeScript job starters for Blank jobs
- require explicit templates for non-interactive job creation and provide runner-specific setup guidance
- validate job template metadata before cloning and preserve `[githubRunner]` in generated deployment specs

## Template and catalog

The official language-neutral template is published at https://github.com/blaxel-templates/template-github-runner. This PR intentionally does not embed its URL or runner assets in toolkit; discovery remains catalog-driven.

The repository contains the complete project at its root:

- `Dockerfile` uses a Docker-capable Ubuntu 24.04 GitHub Actions runner image.
- `start.sh` starts Docker, configures IPv6/NAT64 egress, downloads execution task data, removes execution credentials from the environment, and starts the runner with its one-use JIT configuration.
- `blaxel.toml` declares the job runtime, ephemeral Docker storage, and GitHub repository allow-list.
- `README.md` documents deployment, GitHub App installation, runner labels, and settings-only redeployment.
- `examples/workflow.yml` provides an inactive workflow users can copy into `.github/workflows`.

Template discovery and branch selection are separate:

- The catalog record gives toolkit the canonical name `template-github-runner`, the official repository URL, and the topics `blaxel`, `job`, and `github-runner`.
- Toolkit does not use the catalog record's `defaultBranch` field when cloning. Its existing clone implementation selects `main` normally and selects `develop` when `BL_ENV` is `dev` or `local`.
- The official template repository therefore maintains both branches. They currently point to the same commit and contain identical files.
- Publishing `develop` updates the dev catalog record; publishing `main` updates the production catalog record. This follows the release workflow used by existing `blaxel-templates` repositories.

At runtime, the Blaxel GitHub integration supplies `JIT_CONFIG` in execution task data. The template reads that one-use configuration, registers an ephemeral runner, executes one workflow job, and exits.

## Verification

- `go test ./...`
- `golangci-lint run --new-from-rev=origin/main ./...`
- `go build ./...`
- `make doc`
- clean review passes covering correctness, security, design, test coverage, and scope
- dev and production catalog publication workflows succeeded
- `bl new job --list -o json` returns `template-github-runner` from the dev catalog
- official template deployed successfully as a Blaxel job
- end-to-end smoke workflow completed successfully on the Blaxel runner: `uname -a`, `docker info`, and `docker run --rm hello-world`

Automatic `workflow_job` webhook delivery remains dependent on the Blaxel GitHub App's permissions and event subscription; runtime verification used the same one-use JIT task payload directly after the installed App did not deliver that event. This is outside the toolkit change.

Replaces #342 after the source fork was accidentally deleted and recreated.

Linear: ENG-2244

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Simplifies the post-scaffolding GitHub Runner setup guidance from 4 steps to 2, removing references to manual `blaxel.toml` edits and `--skip-build` deploys. Test assertions updated to match.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 2ab76451f3601136b8077144e95a40d3001ad6d8.</sup>
<!-- /MENDRAL_SUMMARY -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes non-interactive job scaffolding semantics (`-y` without `-t` now fails) and adds pre-clone validation tied to catalog metadata; scope is CLI UX and deploy spec shaping, not auth or data stores.
> 
> **Overview**
> Adds a **GitHub Runner** path to `bl new job`, alongside the existing Python/TypeScript blank starters, driven by what appears in the template catalog.
> 
> Interactive flow now picks **Blank** vs **GitHub Runner** first; runner skips the language picker and blank jobs still use the language/template picker. Non-interactive `bl new job -y` **must** pass `--template` (e.g. `github-runner`, `jobs-py`), with validation before clone so runner templates cannot carry a language and blank jobs must match `python`/`typescript` metadata.
> 
> Job `--list` output is ordered and sanitized for terminal safety; post-create messaging differs for runner (deploy + console repo setup) vs batch jobs, with generic `cd`/`bl run` hints when the directory name is not shell-safe. Docs and examples are updated; deployment generation keeps **`[githubRunner]`** in job specs (covered by an integration test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ab76451f3601136b8077144e95a40d3001ad6d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->