### PR TITLE
fix: suppress pagination hints for machine-readable output

### DIFF
--- a/cli/get.go
+++ b/cli/get.go
@@ -655,10 +655,7 @@ func ListFnPaginated(resource *core.Resource, limit int, cursor string, fetchAll
 			core.ExitWithError(err)
 		}
 		core.Output(*resource, result.Items, core.GetOutputFormat())
-		if result.Meta.HasMore && result.Meta.NextCursor != "" {
-			fmt.Fprintf(os.Stderr, "\nShowing %d of %d %s. To see the next page run:\n  bl get %s --cursor %s\n",
-				len(result.Items), result.Meta.Total, resource.Plural, resource.Plural, result.Meta.NextCursor)
-		}
+		printCursorHint(resource, result, core.GetOutputFormat())
 		return
 	}
 
@@ -670,10 +667,7 @@ func ListFnPaginated(resource *core.Resource, limit int, cursor string, fetchAll
 			core.ExitWithError(err)
 		}
 		core.Output(*resource, result.Items, core.GetOutputFormat())
-		if result.Meta.HasMore && result.Meta.NextCursor != "" {
-			fmt.Fprintf(os.Stderr, "\nShowing %d of %d %s. To see more run:\n  bl get %s --cursor %s\n",
-				len(result.Items), result.Meta.Total, resource.Plural, resource.Plural, result.Meta.NextCursor)
-		}
+		printCursorHint(resource, result, core.GetOutputFormat())
 		return
 	}
 
@@ -684,6 +678,15 @@ func ListFnPaginated(resource *core.Resource, limit int, cursor string, fetchAll
 		core.ExitWithError(err)
 	}
 	core.Output(*resource, result.Items, core.GetOutputFormat())
+	printCursorHint(resource, result, core.GetOutputFormat())
+}
+
+// printCursorHint prints the next-page hint on stderr. Skipped for
+// machine-readable output formats (json/yaml) so piped output stays clean.
+func printCursorHint(resource *core.Resource, result core.PaginatedResult, format string) {
+	if format == "json" || format == "yaml" {
+		return
+	}
 	if result.Meta.HasMore && result.Meta.NextCursor != "" {
 		fmt.Fprintf(os.Stderr, "\nShowing %d of %d %s. To see the next page run:\n  bl get %s --cursor %s\n",
 			len(result.Items), result.Meta.Total, resource.Plural, resource.Plural, result.Meta.NextCursor)

--- a/cli/get_test.go
+++ b/cli/get_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/blaxel-ai/toolkit/cli/core"
+)
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = orig
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	return string(buf[:n])
+}
+
+func TestPrintCursorHint(t *testing.T) {
+	resource := &core.Resource{Kind: "Agent", Plural: "agents"}
+	result := core.PaginatedResult{
+		Items: []any{1, 2},
+		Meta:  core.PaginationMeta{HasMore: true, NextCursor: "abc", Total: 10},
+	}
+
+	for _, format := range []string{"json", "yaml"} {
+		if out := captureStderr(t, func() { printCursorHint(resource, result, format) }); out != "" {
+			t.Errorf("format %q: expected no hint, got %q", format, out)
+		}
+	}
+
+	out := captureStderr(t, func() { printCursorHint(resource, result, "pretty") })
+	if !strings.Contains(out, "--cursor abc") {
+		t.Errorf("expected cursor hint, got %q", out)
+	}
+
+	noMore := core.PaginatedResult{Items: []any{1}, Meta: core.PaginationMeta{HasMore: false}}
+	if out := captureStderr(t, func() { printCursorHint(resource, noMore, "pretty") }); out != "" {
+		t.Errorf("expected no hint when HasMore is false, got %q", out)
+	}
+}


### PR DESCRIPTION
Fixes ENG-3929

Pagination cursor hints were previously printed to stderr for all output formats, including `json` and `yaml`. This would pollute machine-readable output, making it difficult to parse programmatically.

This change ensures the hint is only displayed for human-readable formats, while also refactoring the hint logic into a dedicated function with tests.
