### PR TITLE
chore: restore toolkit lint baseline

### DIFF
--- a/cli/apply.go
+++ b/cli/apply.go
@@ -773,15 +773,16 @@ func PutFn(resource *core.Resource, resourceName string, name string, resourceOb
 		result.CallbackSecret = extractCallbackSecret(opResult.Response)
 	}
 
-	if resourceName == "Preview" {
+	switch resourceName {
+	case "Preview":
 		printPreviewURL(opResult.Response, resourceName, name, "configured")
-	} else if resourceName == "PreviewToken" {
+	case "PreviewToken":
 		if tokenURL := buildPreviewTokenURL(opResult.Response, parentName, metadata); tokenURL != "" {
 			core.Print(fmt.Sprintf("Resource %s:%s configured url=%s\n", resourceName, name, tokenURL))
 		} else {
 			core.Print(fmt.Sprintf("Resource %s:%s configured\n", resourceName, name))
 		}
-	} else {
+	default:
 		core.Print(fmt.Sprintf("Resource %s:%s configured\n", resourceName, name))
 	}
 
@@ -817,15 +818,16 @@ func PostFn(resource *core.Resource, resourceName string, name string, resourceO
 		result.CallbackSecret = extractCallbackSecret(opResult.Response)
 	}
 
-	if resourceName == "Preview" {
+	switch resourceName {
+	case "Preview":
 		printPreviewURL(opResult.Response, resourceName, name, "created")
-	} else if resourceName == "PreviewToken" {
+	case "PreviewToken":
 		if tokenURL := buildPreviewTokenURL(opResult.Response, parentName, metadata); tokenURL != "" {
 			core.Print(fmt.Sprintf("Resource %s:%s created url=%s\n", resourceName, name, tokenURL))
 		} else {
 			core.Print(fmt.Sprintf("Resource %s:%s created\n", resourceName, name))
 		}
-	} else {
+	default:
 		core.Print(fmt.Sprintf("Resource %s:%s created\n", resourceName, name))
 	}
 

--- a/cli/core/sandbox_templates.go
+++ b/cli/core/sandbox_templates.go
@@ -193,7 +193,6 @@ func PromptSandboxTemplateOptions(directory string, templates Templates) Templat
 
 func sandboxTemplatesForDisplay(templates Templates) Templates {
 	knownTemplates := Templates{}
-	remainingTemplates := Templates{}
 
 	for _, name := range []string{sandboxScratchTemplate, sandboxClaudeCodeTemplate, sandboxCodexTemplate} {
 		for _, t := range templates {
@@ -208,10 +207,7 @@ func sandboxTemplatesForDisplay(templates Templates) Templates {
 		return knownTemplates
 	}
 
-	for _, t := range templates {
-		remainingTemplates = append(remainingTemplates, t)
-	}
-	return remainingTemplates
+	return append(Templates{}, templates...)
 }
 
 func sandboxTemplateLabel(t Template) string {
@@ -325,7 +321,7 @@ func removeSandboxFile(dir, name string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open sandbox directory: %w", err)
 	}
-	defer root.Close()
+	defer func() { _ = root.Close() }()
 	return root.Remove(name)
 }
 
@@ -338,7 +334,7 @@ func writeSandboxFile(dir, name string, data []byte, perm os.FileMode) error {
 	if err != nil {
 		return fmt.Errorf("failed to open sandbox directory: %w", err)
 	}
-	defer root.Close()
+	defer func() { _ = root.Close() }()
 
 	info, err := root.Lstat(name)
 	if err == nil {

--- a/cli/deploy_integration_test.go
+++ b/cli/deploy_integration_test.go
@@ -988,7 +988,7 @@ func TestZipContainsDockerConfig(t *testing.T) {
 	// Read the zip and verify .docker/config.json is present
 	reader, err := zip.OpenReader(d.archive.Name())
 	require.NoError(t, err)
-	defer reader.Close()
+	defer func() { require.NoError(t, reader.Close()) }()
 
 	var found bool
 	for _, f := range reader.File {
@@ -997,8 +997,9 @@ func TestZipContainsDockerConfig(t *testing.T) {
 			rc, err := f.Open()
 			require.NoError(t, err)
 			data, err := io.ReadAll(rc)
-			rc.Close()
+			closeErr := rc.Close()
 			require.NoError(t, err)
+			require.NoError(t, closeErr)
 
 			var config core.DockerConfig
 			require.NoError(t, json.Unmarshal(data, &config))
@@ -1039,7 +1040,7 @@ func TestZipExcludesRawDockerDir(t *testing.T) {
 
 	reader, err := zip.OpenReader(d.archive.Name())
 	require.NoError(t, err)
-	defer reader.Close()
+	defer func() { require.NoError(t, reader.Close()) }()
 
 	dockerConfigCount := 0
 	for _, f := range reader.File {
@@ -1048,8 +1049,9 @@ func TestZipExcludesRawDockerDir(t *testing.T) {
 			rc, err := f.Open()
 			require.NoError(t, err)
 			data, err := io.ReadAll(rc)
-			rc.Close()
+			closeErr := rc.Close()
 			require.NoError(t, err)
+			require.NoError(t, closeErr)
 
 			// Should contain the injected config, not the on-disk one
 			var config core.DockerConfig
@@ -1081,7 +1083,7 @@ func TestZipNoDockerConfigWhenNil(t *testing.T) {
 
 	reader, err := zip.OpenReader(d.archive.Name())
 	require.NoError(t, err)
-	defer reader.Close()
+	defer func() { require.NoError(t, reader.Close()) }()
 
 	for _, f := range reader.File {
 		assert.NotEqual(t, ".docker/config.json", f.Name, "should not contain .docker/config.json when dockerConfigJSON is nil")

--- a/cli/drive.go
+++ b/cli/drive.go
@@ -175,7 +175,7 @@ the blfs filesystem. It can be used as a recovery tool when mounts are lost.`,
 				core.PrintError("Drive mount", err)
 				core.ExitWithError(err)
 			}
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 
 			respBody, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -243,7 +243,7 @@ func DriveUnmountCmd() *cobra.Command {
 				core.PrintError("Drive unmount", err)
 				core.ExitWithError(err)
 			}
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 
 			respBody, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -301,7 +301,7 @@ func DriveMountsCmd() *cobra.Command {
 				core.PrintError("Drive mounts", err)
 				core.ExitWithError(err)
 			}
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 
 			respBody, err := io.ReadAll(resp.Body)
 			if err != nil {

--- a/cli/push.go
+++ b/cli/push.go
@@ -751,7 +751,7 @@ func renderCodeBlock(code string) string {
 	var b strings.Builder
 	b.WriteString(border.Sprint("  ┌─────────────────────────────────────────────────────────") + "\n")
 	for _, line := range strings.Split(code, "\n") {
-		b.WriteString(fmt.Sprintf("  %s %s\n", border.Sprint("│"), codeColor.Sprint(line)))
+		fmt.Fprintf(&b, "  %s %s\n", border.Sprint("│"), codeColor.Sprint(line))
 	}
 	b.WriteString(border.Sprint("  └─────────────────────────────────────────────────────────"))
 	return b.String()

--- a/cli/run.go
+++ b/cli/run.go
@@ -335,11 +335,12 @@ This is useful for testing specific endpoints or non-standard API calls.`,
 					fmt.Println()
 				}
 				// For JSON output, wrap the accumulated text
-				if outputFormat == "json" {
+				switch outputFormat {
+				case "json":
 					result := map[string]string{"output": accumulated.String()}
 					jsonData, _ := json.MarshalIndent(result, "", "  ")
 					fmt.Println(string(jsonData))
-				} else if outputFormat == "yaml" {
+				case "yaml":
 					result := map[string]string{"output": accumulated.String()}
 					yamlData, _ := yaml.Marshal(result)
 					fmt.Print(string(yamlData))


### PR DESCRIPTION
Fixes ENG-4053

## Summary

- handle the 10 existing unchecked `Close` results identified by `golangci-lint`
- apply the five behavior-preserving simplifications reported by `staticcheck`
- restore a green whole-repository `make lint` baseline for follow-up CLI work

## Why

`main` currently fails its canonical lint target with 15 pre-existing findings. Keeping this mechanical cleanup separate prevents the ENG-4048 Sentry behavior change from absorbing unrelated lint debt while allowing that follow-up PR to pass the literal repository gate.

No user-facing behavior is intended to change.

## Validation

- `make test`
- `make lint`
- `go vet ./...`
- `go build ./...`

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Mechanical lint cleanup: converts if/else-if chains to switch statements, silences unchecked `Close()` return values (either with `_ =` discard or `require.NoError` in tests), removes an unused variable, and simplifies a slice copy.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 378b62338926677616f4575e9fd2184f847c1455.</sup>
<!-- /MENDRAL_SUMMARY -->