### PR TITLE
feat(cli): support glob patterns in .blaxelignore

### DIFF
--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -24,6 +24,7 @@ import (
 	"github.com/blaxel-ai/toolkit/cli/server"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/fatih/color"
+	"github.com/moby/patternmatcher"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -1978,8 +1979,7 @@ func (d *Deployment) IgnoredPaths() []string {
 
 	// Parse the .blaxelignore file, filtering out comments and empty lines
 	lines := strings.Split(string(content), "\n")
-	// Always exclude .env.build regardless of .blaxelignore content
-	ignoredPaths := []string{".env.build"}
+	ignoredPaths := []string{}
 	for _, line := range lines {
 		// Trim whitespace
 		line = strings.TrimSpace(line)
@@ -1997,23 +1997,54 @@ func (d *Deployment) IgnoredPaths() []string {
 		}
 		ignoredPaths = append(ignoredPaths, line)
 	}
-	return ignoredPaths
+	// Keep .env.build excluded even if an earlier pattern re-includes it.
+	return append(ignoredPaths, ".env.build")
 }
 
-func (d *Deployment) shouldIgnorePath(path string, ignoredPaths []string) bool {
-	sep := string(filepath.Separator)
-	for _, ignoredPath := range ignoredPaths {
-		if strings.HasPrefix(path, filepath.Join(d.cwd, ignoredPath)) {
-			return true
-		}
-		if strings.Contains(path, sep+ignoredPath+sep) {
-			return true
-		}
-		if strings.HasSuffix(path, sep+ignoredPath) {
-			return true
-		}
+type ignoredPathMatcher struct {
+	root    string
+	matcher *patternmatcher.PatternMatcher
+}
+
+func newIgnoredPathMatcher(root string, patterns []string) (*ignoredPathMatcher, error) {
+	normalizedPatterns := make([]string, 0, len(patterns))
+	for _, pattern := range patterns {
+		normalizedPatterns = append(normalizedPatterns, normalizeIgnorePattern(pattern))
 	}
-	return false
+
+	matcher, err := patternmatcher.New(normalizedPatterns)
+	if err != nil {
+		return nil, fmt.Errorf("invalid .blaxelignore pattern: %w", err)
+	}
+	return &ignoredPathMatcher{root: root, matcher: matcher}, nil
+}
+
+// normalizeIgnorePattern preserves the previous behavior where literal paths
+// matched at any depth. Glob patterns retain Docker ignore-file semantics.
+func normalizeIgnorePattern(pattern string) string {
+	negated := strings.HasPrefix(pattern, "!")
+	if negated {
+		pattern = pattern[1:]
+	}
+
+	anchored := strings.HasPrefix(pattern, "/") || strings.HasPrefix(pattern, "./")
+	pattern = strings.TrimPrefix(strings.TrimPrefix(pattern, "./"), "/")
+	if !anchored && !strings.ContainsAny(pattern, "*?[") {
+		pattern = "**/" + pattern
+	}
+
+	if negated {
+		return "!" + pattern
+	}
+	return pattern
+}
+
+func (m *ignoredPathMatcher) matches(path string) (bool, error) {
+	relativePath, err := filepath.Rel(m.root, path)
+	if err != nil {
+		return false, fmt.Errorf("resolve ignored path %q: %w", path, err)
+	}
+	return m.matcher.MatchesOrParentMatches(toArchivePath(relativePath))
 }
 
 // toArchivePath normalizes a file path for use in zip/tar archives.
@@ -2090,9 +2121,13 @@ func (d *Deployment) createArchive(_ string, writer archiveWriter) error {
 	config := core.GetConfig()
 
 	// For volume-template, don't apply ignore logic
-	var ignoredPaths []string
+	var ignoreMatcher *ignoredPathMatcher
 	if !core.IsVolumeTemplate(config.Type) {
-		ignoredPaths = d.IgnoredPaths()
+		var err error
+		ignoreMatcher, err = newIgnoredPathMatcher(d.cwd, d.IgnoredPaths())
+		if err != nil {
+			return err
+		}
 	}
 
 	// Determine the root directory to archive
@@ -2134,8 +2169,14 @@ func (d *Deployment) createArchive(_ string, writer archiveWriter) error {
 		}
 
 		// Only apply ignore logic for non-volume-template types
-		if !core.IsVolumeTemplate(config.Type) && d.shouldIgnorePath(path, ignoredPaths) {
-			return nil
+		if ignoreMatcher != nil {
+			ignored, err := ignoreMatcher.matches(path)
+			if err != nil {
+				return err
+			}
+			if ignored {
+				return nil
+			}
 		}
 
 		// For volume-templates, exclude blaxel.toml from the archive

--- a/cli/deploy_test.go
+++ b/cli/deploy_test.go
@@ -159,11 +159,9 @@ build
 
 func TestDeploymentShouldIgnorePath(t *testing.T) {
 	cwd := filepath.FromSlash("/home/user/project")
-	d := Deployment{
-		cwd: cwd,
-	}
-
 	ignoredPaths := []string{".git", "node_modules", "dist"}
+	matcher, err := newIgnoredPathMatcher(cwd, ignoredPaths)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name     string
@@ -181,10 +179,60 @@ func TestDeploymentShouldIgnorePath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := d.shouldIgnorePath(tt.path, ignoredPaths)
+			result, err := matcher.matches(tt.path)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestDeploymentShouldIgnoreGlobPatterns(t *testing.T) {
+	cwd := filepath.FromSlash("/home/user/project")
+	matcher, err := newIgnoredPathMatcher(cwd, []string{
+		"**/*.test.ts",
+		"**/.env.*",
+		"!sandbox/keep.test.ts",
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"root test file", filepath.Join(cwd, "app.test.ts"), true},
+		{"nested test file", filepath.Join(cwd, "sandbox", "src", "app.test.ts"), true},
+		{"nested environment file", filepath.Join(cwd, "sandbox", ".env.local"), true},
+		{"negated test file", filepath.Join(cwd, "sandbox", "keep.test.ts"), false},
+		{"regular source file", filepath.Join(cwd, "sandbox", "src", "app.ts"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := matcher.matches(tt.path)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDeploymentShouldIgnoreAnchoredLiteralPath(t *testing.T) {
+	cwd := filepath.FromSlash("/home/user/project")
+	matcher, err := newIgnoredPathMatcher(cwd, []string{"./infra"})
+	require.NoError(t, err)
+
+	rootInfra, err := matcher.matches(filepath.Join(cwd, "infra", "main.tf"))
+	require.NoError(t, err)
+	assert.True(t, rootInfra)
+
+	nestedInfra, err := matcher.matches(filepath.Join(cwd, "sandbox", "infra", "main.tf"))
+	require.NoError(t, err)
+	assert.False(t, nestedInfra)
+}
+
+func TestNewIgnoredPathMatcherRejectsInvalidPattern(t *testing.T) {
+	_, err := newIgnoredPathMatcher("/home/user/project", []string{"[invalid"})
+	require.ErrorContains(t, err, "invalid .blaxelignore pattern")
 }
 
 func TestResultKinds(t *testing.T) {
@@ -318,12 +366,9 @@ func TestToArchivePath(t *testing.T) {
 
 func TestDeploymentShouldIgnorePathWithDirectories(t *testing.T) {
 	cwd := filepath.FromSlash("/home/user/project")
-	d := Deployment{
-		cwd: cwd,
-	}
-
-	// Note: shouldIgnorePath uses string matching, not glob patterns
 	ignoredPaths := []string{"logs", "build", "tmp"}
+	matcher, err := newIgnoredPathMatcher(cwd, ignoredPaths)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name     string
@@ -341,7 +386,8 @@ func TestDeploymentShouldIgnorePathWithDirectories(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := d.shouldIgnorePath(tt.path, ignoredPaths)
+			result, err := matcher.matches(tt.path)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/jedib0t/go-pretty/v6 v6.7.9
 	github.com/joho/godotenv v1.5.1
+	github.com/moby/patternmatcher v0.6.1
 	github.com/qeesung/image2ascii v1.0.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwX
 github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
 github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
 github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
+github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x084U=
+github.com/moby/patternmatcher v0.6.1/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D264iyp3TiX5OmNcI5cIARiQI=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6/go.mod h1:CJlz5H+gyd6CUWT45Oy4q24RdLyn7Md9Vj2/ldJBSIo=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=


### PR DESCRIPTION
Fixes ENG-4085

## Summary

- match `.blaxelignore` entries with Docker's maintained pattern matcher
- support `*`, `?`, `**`, character classes, and ordered `!` exclusions
- preserve the existing behavior where unanchored literal paths match at any depth
- compile patterns once per archive and return a clear error for invalid patterns
- keep `.env.build` unconditionally excluded

This makes it practical to share one ignore policy between `.dockerignore` and `.blaxelignore`, including patterns such as `**/*.test.ts` and `**/.env.*`.

## Testing

- `go test -count=1 ./...`
- `go build ./...`
- `golangci-lint run --new-from-rev=origin/main` (0 new issues)

## Lint baseline

`make lint` still reports 15 pre-existing findings in unrelated files on `main`; this change introduces none.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Replaces the simple string-prefix/contains/suffix ignore-path matching with Docker's `patternmatcher` library, enabling glob patterns (`*`, `**`, `?`, `[...]`) and ordered `!` exclusions in `.blaxelignore`. Unanchored literal paths are automatically prefixed with `**/` to preserve existing depth-agnostic matching behavior. `.env.build` is appended last to remain unconditionally excluded.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 53d41e8cc24d6e9ddf5433ee8517b12e1105305d.</sup>
<!-- /MENDRAL_SUMMARY -->