### PR TITLE
fix(cli): resolve environment from the targeted workspace after flag parsing (ENG-4262)

### DIFF
--- a/cli/core/root.go
+++ b/cli/core/root.go
@@ -266,7 +266,17 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		blaxel.ApplyEnvironmentOverrides()
+		// Flags are parsed by now: make the resolved workspace (flag > BL_WORKSPACE
+		// > context) authoritative for the whole process and re-initialize the
+		// environment from it. Without this, a -w override keeps the current
+		// context's env, and SDK client constructors that re-derive the workspace
+		// from BL_WORKSPACE/context send requests to the wrong environment
+		// domain (ENG-4262). InitializeEnvironment ends by applying the BL_* URL
+		// overrides, preserving the previous behavior here.
+		if workspace != "" {
+			_ = os.Setenv("BL_WORKSPACE", workspace)
+		}
+		blaxel.InitializeEnvironment(workspace)
 
 		// Skip config reading for deploy and push commands as they handle their own config logic
 		if cmd.Name() != "deploy" && cmd.Name() != "push" {


### PR DESCRIPTION
Fixes ENG-4262

## What

With the CLI context on an `env: dev` workspace, targeting a prod workspace via `-w` sent requests to the dev environment domain (and printed dev console links). Two layers caused it:

1. `Execute()` resolves the workspace and calls `blaxel.InitializeEnvironment(...)` **before** Cobra parses flags, so `-w` never influenced the environment.
2. Even with a later re-init, sdk-go client constructors (`NewDefaultClient`, `DefaultClientOptions`) re-derive the workspace from `BL_WORKSPACE`/current context and re-initialize the environment, clobbering the corrected value.

The fix runs in `PersistentPreRunE` (after flag parsing): the resolved workspace (flag > `BL_WORKSPACE` > context) is exported as `BL_WORKSPACE` so every later SDK re-derivation agrees, and the environment is re-initialized from it. `InitializeEnvironment` ends by applying `BL_*` URL overrides, preserving the previous `ApplyEnvironmentOverrides()` behavior in that spot; `BL_ENV` still takes precedence inside it.

## Verification (bl built from this branch; config: context `onboarder` = dev, `calibrator` = prod)

| Command | Before | After |
| --- | --- | --- |
| `bl run job <name> -w calibrator` | `POST https://run.blaxel.dev/...` → 401 Unauthorized (prod token to dev) | `POST https://run.blaxel.ai/...` → 404 Not Found (correct domain, job intentionally nonexistent) |
| `bl run job <name>` (no `-w`, dev context) | `run.blaxel.dev` | `run.blaxel.dev` (unchanged) |

The dev console-link symptom on `bl deploy -w <prod-ws>` is the same `currentConfig` (AppURL) and is corrected by the same re-init.

- `go test ./cli/...` passes; `golangci-lint run cli/core/` clean.

## Note

A config-fixture regression test for mixed-env `-w` needs a temp-HOME harness that doesn't exist in `cli/core` tests yet; the sdk-go side (`LoadEnvironmentFromConfig` per-workspace env) is already covered in `test/environments_test.go`. Happy to add the harness in a follow-up if wanted.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Moves environment initialization into `PersistentPreRunE` (after Cobra parses flags) so that `-w` workspace overrides correctly determine the environment (dev vs prod URLs). Also exports the resolved workspace as `BL_WORKSPACE` so downstream SDK client constructors agree on the target workspace.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 8f399a29b96542883aa656d54366634136d4e87e.</sup>
<!-- /MENDRAL_SUMMARY -->