### PR TITLE
fix(cli): show re-login guidance when token refresh is unavailable

### DIFF
--- a/cli/token.go
+++ b/cli/token.go
@@ -76,21 +76,9 @@ export TOKEN=$(bl token)
 				core.ExitWithError(err)
 			}
 
-			// Get workspace to check if access is allowed + it refreshes the token if needed.
-			client, err := blaxel.NewClientFromConfig(workspace)
-			if err != nil {
-				err := fmt.Errorf("failed to create client for workspace '%s': %w", workspace, err)
-				core.PrintError("token", err)
-				core.ExitWithError(err)
-			}
-			_, err = client.Workspaces.Get(context.Background(), workspace, blaxel.WorkspaceGetParams{})
-			if err != nil {
-				err := fmt.Errorf("failed to get workspace '%s': %w", workspace, err)
-				core.PrintError("token", err)
-				core.ExitWithError(err)
-			}
-
-			// Load credentials for the workspace
+			// Load credentials before validating workspace access so local credential
+			// problems can return actionable login guidance without first failing on
+			// a workspace API call.
 			credentials, err := blaxel.LoadCredentials(workspace)
 			if err != nil {
 				err := fmt.Errorf("failed to load credentials for workspace '%s': %w", workspace, err)
@@ -113,6 +101,22 @@ export TOKEN=$(bl token)
 				core.ExitWithError(err)
 			}
 
+			// Get workspace to check if access is allowed. Keep this after token
+			// retrieval so expired non-refreshable tokens fail before any API call,
+			// but before printing so inaccessible workspaces never leak a token.
+			client, err := blaxel.NewClientFromConfig(workspace)
+			if err != nil {
+				err := fmt.Errorf("failed to create client for workspace '%s': %w", workspace, err)
+				core.PrintError("token", err)
+				core.ExitWithError(err)
+			}
+			_, err = client.Workspaces.Get(context.Background(), workspace, blaxel.WorkspaceGetParams{})
+			if err != nil {
+				err := fmt.Errorf("failed to get workspace '%s': %w", workspace, err)
+				core.PrintError("token", err)
+				core.ExitWithError(err)
+			}
+
 			// Output the token
 			fmt.Println(token)
 		},
@@ -124,6 +128,9 @@ export TOKEN=$(bl token)
 func tokenForCredentials(ctx context.Context, workspace string, credentials blaxel.Credentials) (string, error) {
 	headers, err := authHeadersForCredentials(ctx, credentials, workspace)
 	if err != nil {
+		if credentials.AccessToken != "" && credentials.RefreshToken != "" {
+			return "", fmt.Errorf("%w. Please run 'bl login %s'", err, workspace)
+		}
 		return "", err
 	}
 

--- a/cli/token_test.go
+++ b/cli/token_test.go
@@ -1,10 +1,14 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -38,6 +42,24 @@ func TestTokenForCredentialsUsesRefreshedBearer(t *testing.T) {
 	assert.Equal(t, refreshedToken, token)
 }
 
+func TestTokenForCredentialsRefreshFailureShowsLoginGuidance(t *testing.T) {
+	previous := authHeadersForCredentials
+	authHeadersForCredentials = func(ctx context.Context, credentials blaxel.Credentials, workspace string) (map[string]string, error) {
+		return nil, fmt.Errorf("failed to refresh token: invalid refresh token")
+	}
+	t.Cleanup(func() { authHeadersForCredentials = previous })
+
+	token, err := tokenForCredentials(context.Background(), "main", blaxel.Credentials{
+		AccessToken:  "expired-access-token",
+		RefreshToken: "invalid-refresh-token",
+	})
+
+	require.Error(t, err)
+	assert.Empty(t, token)
+	assert.Contains(t, err.Error(), "invalid refresh token")
+	assert.Contains(t, err.Error(), "bl login main")
+}
+
 func TestTokenForCredentialsRejectsExpiredUnrefreshedBearer(t *testing.T) {
 	expiredToken := testJWT(t, time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
 
@@ -56,6 +78,57 @@ func TestTokenForCredentialsRejectsExpiredUnrefreshedBearer(t *testing.T) {
 	require.Error(t, err)
 	assert.Empty(t, token)
 	assert.Contains(t, err.Error(), "bl login main")
+}
+
+func TestTokenCmdExpiredAccessTokenWithoutRefreshShowsLoginGuidance(t *testing.T) {
+	workspace := "eng-2815-workspace"
+	expiredToken := testJWT(t, time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".blaxel")
+	require.NoError(t, os.MkdirAll(configDir, 0700))
+	config := fmt.Sprintf(`context:
+  workspace: %s
+workspaces:
+  - name: %s
+    credentials:
+      access_token: %s
+`, workspace, workspace, expiredToken)
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(config), 0600))
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestTokenCmdExpiredAccessTokenWithoutRefreshShowsLoginGuidanceHelper")
+	cmd.Env = append(os.Environ(),
+		"BLAXEL_TEST_TOKEN_HOME="+home,
+		"BLAXEL_TEST_TOKEN_WORKSPACE="+workspace,
+		"HOME="+home,
+	)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+
+	require.Error(t, err)
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 1, exitErr.ExitCode())
+	assert.Empty(t, stdout.String())
+	assert.Contains(t, stderr.String(), "bl login "+workspace)
+}
+
+func TestTokenCmdExpiredAccessTokenWithoutRefreshShowsLoginGuidanceHelper(t *testing.T) {
+	home := os.Getenv("BLAXEL_TEST_TOKEN_HOME")
+	workspace := os.Getenv("BLAXEL_TEST_TOKEN_WORKSPACE")
+	if home == "" || workspace == "" {
+		t.Skip("helper only runs in a subprocess")
+	}
+
+	require.NoError(t, os.Setenv("HOME", home))
+	cmd := TokenCmd()
+	cmd.SetArgs([]string{workspace})
+	require.NoError(t, cmd.Execute())
 }
 
 func TestBearerTokenFromHeaders(t *testing.T) {


### PR DESCRIPTION
## Summary

- load and validate local credentials before making the workspace access request in `bl token`
- retrieve/refresh the token before workspace validation so expired access-only credentials return `bl login <workspace>` guidance without ever printing the token
- preserve workspace validation before stdout output, and add the same login guidance when an OAuth refresh attempt fails
- add full-command regression coverage for the expired-token/no-refresh path

Fixes ENG-2815

## Verification

- `go test ./cli -count=1 -run 'Test(Token|Bearer)'`
- `make test`
- `make lint`
- `go build ./...`

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Reorders the `bl token` command logic to load and validate credentials before making the workspace API call. This ensures that expired/non-refreshable tokens produce actionable "bl login" guidance instead of cryptic API failures. Adds a login guidance message when OAuth refresh fails, and includes a subprocess-based integration test for the expired-token-without-refresh path.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 22c4b55215f8c0ae21cb7c645702cc844d060c79.</sup>
<!-- /MENDRAL_SUMMARY -->