### PR TITLE
ci: restore automatic Homebrew updates

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -72,4 +72,4 @@ brews:
       owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
       name: homebrew-blaxel
       pull_request:
-        enabled: true
+        enabled: false


### PR DESCRIPTION
Fixes ENG-4325

## Summary

- restore direct Homebrew formula updates during CLI releases
- prevent `curl` and Homebrew versions from drifting while a formula PR waits for merge

## Change

Disable GoReleaser pull-request mode for `homebrew-blaxel`. Future releases will update the tap's default branch directly.

## Validation

- `make lint`
- `go build ./...`
- `git diff --check`
- `goreleaser check --config .goreleaser.yaml` confirmed the configuration is valid; existing deprecation warnings remain
