### PR TITLE
chore: remove the dead sdk-controlplane make target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,11 @@ Entry point: `main.go` → `cli.Execute` (`cli/root.go`) → `core.Execute`
 | Integration tests (needs `BL_API_KEY`, `BL_WORKSPACE`) | `make test-integration` |
 | Lint | `make lint` (`golangci-lint run`) |
 | Regenerate CLI docs | `make doc` |
-| Regenerate SDK from controlplane | `make sdk-controlplane [branch=<x>]` |
+| Update the Go SDK | `go get github.com/blaxel-ai/sdk-go@vX.Y.Z && go mod tidy` |
+
+The SDK is not generated from this repo: `blaxel-ai/sdk-go` is generated in
+`blaxel-ai/controlplane` (`.stainless/`) and released with release-please. Here
+you only ever bump the dependency to a released tag.
 
 Always run `make lint` and `go build ./...` before committing. Integration
 tests hit the real platform — never run them against prod data; use a dev

--- a/Makefile
+++ b/Makefile
@@ -25,15 +25,6 @@ build-dev:
 	rm -r ./bin;
 	@echo "✅ Binary built: ./bin/blaxel"
 
-sdk-controlplane:
-	@if [ -n "$(branch)" ]; then \
-		echo "📦 Generating SDK from controlplane branch: $(branch)"; \
-		go run github.com/nicholasgasior/goproc/cmd/goproc@latest go.mod github.com/blaxel-ai/sdk-go "github.com/blaxel-ai/controlplane/.stainless/openapi.yml@$(branch)"; \
-	else \
-		echo "📦 Generating SDK from controlplane main branch"; \
-		go run github.com/nicholasgasior/goproc/cmd/goproc@latest go.mod github.com/blaxel-ai/sdk-go; \
-	fi
-
 doc:
 	rm -rf docs
 	go run main.go docs --format=markdown --output=docs


### PR DESCRIPTION
Fixes ENG-4453

## What

Deletes the `sdk-controlplane` target from the Makefile, and the line documenting it in `AGENTS.md`.

## Why

The target ran `go run github.com/nicholasgasior/goproc/cmd/goproc@latest ...`. That module does not exist: 404 on both `proxy.golang.org` and GitHub. So `make sdk-controlplane` has only been able to fail.

It also implied the SDK can be regenerated from this repo, which is not how it works. `blaxel-ai/sdk-go` is generated in `blaxel-ai/controlplane` (`.stainless/`) and released by release-please. Here we only bump the dependency:

```bash
go get github.com/blaxel-ai/sdk-go@vX.Y.Z && go mod tidy
```

`AGENTS.md` now says that instead.

## Verified

`make lint` (0 issues), `make test` (all packages pass), `go build ./...`.

## Note

The Makefile's catch-all `%:` rule means anyone still typing `make sdk-controlplane` now gets a silent no-op instead of an error. Happy to add an explicit "removed, use go get" stub if you'd rather it be loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/toolkit/pull/365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes the dead `sdk-controlplane` Makefile target (which depended on a now-404 Go module) and replaces its AGENTS.md documentation with correct instructions for bumping the SDK dependency.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 9c72a48d01de31a8443067f8c5341b1fb07fc03b.</sup>
<!-- /MENDRAL_SUMMARY -->