### PR TITLE
Keep labels declared in blaxel.toml

### DIFF
--- a/cli/core/config.go
+++ b/cli/core/config.go
@@ -304,6 +304,11 @@ type Config struct {
 	Port         int                       `toml:"port,omitempty"`
 	Image        string                    `toml:"image,omitempty"`
 	Build        *BuildConfig              `toml:"build,omitempty"`
+	// Labels are applied to the deployed resource's metadata. The CLI adds its
+	// own (x-blaxel-auto-generated, x-blaxel-experimental) on top; a label set
+	// here is otherwise the only way to keep one across a deploy, since the
+	// deploy rewrites metadata.labels wholesale.
+	Labels map[string]string `toml:"labels,omitempty"`
 }
 
 // blaxelTomlWarning stores any warning from parsing blaxel.toml

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -808,6 +808,12 @@ func (d *Deployment) GenerateDeployment(skipBuild bool) core.Result {
 		Spec["public"] = *config.Public
 	}
 	labels := map[string]interface{}{}
+	// Declared labels first: the CLI's own are set below and must win, but
+	// anything the user asked for has to survive the deploy. Without this the
+	// map is rebuilt from scratch on every deploy and every other label is lost.
+	for name, value := range config.Labels {
+		labels[name] = value
+	}
 	if config.Image == "" && (!skipBuild || core.IsVolumeTemplate(config.Type)) {
 		labels["x-blaxel-auto-generated"] = "true"
 	}

--- a/cli/deploy_labels_test.go
+++ b/cli/deploy_labels_test.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blaxel-ai/toolkit/cli/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A deploy rebuilds metadata.labels from scratch, so anything not declared in
+// blaxel.toml is dropped on every deploy. That silently defeats labels the
+// platform reads at deploy time — a resource labelled through the API loses it
+// the next time the CLI runs.
+func TestGenerateDeploymentKeepsDeclaredLabels(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "blaxel.toml"), []byte(`
+type = "sandbox"
+name = "labelled-sandbox"
+
+[labels]
+"x-blaxel-builder" = "sandbox"
+team = "platform"
+`), 0o600))
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+		core.ResetConfig()
+	})
+
+	core.ResetConfig()
+	core.ReadConfigToml(".", true)
+	require.Equal(t, map[string]string{
+		"x-blaxel-builder": "sandbox",
+		"team":             "platform",
+	}, core.GetConfig().Labels, "labels were not read from blaxel.toml")
+
+	d := &Deployment{name: "labelled-sandbox"}
+	meta, ok := d.GenerateDeployment(false).Metadata.(map[string]interface{})
+	require.True(t, ok, "metadata is not a map")
+	labels, ok := meta["labels"].(map[string]interface{})
+	require.True(t, ok, "metadata.labels is missing")
+
+	assert.Equal(t, "sandbox", labels["x-blaxel-builder"])
+	assert.Equal(t, "platform", labels["team"])
+	// The CLI's own label still gets set alongside them.
+	assert.Equal(t, "true", labels["x-blaxel-auto-generated"])
+}
+
+// The CLI owns these two, so a manifest must not be able to claim them.
+func TestGenerateDeploymentOwnLabelsWin(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "blaxel.toml"), []byte(`
+type = "sandbox"
+name = "liar"
+
+[labels]
+"x-blaxel-auto-generated" = "false"
+`), 0o600))
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+		core.ResetConfig()
+	})
+
+	core.ResetConfig()
+	core.ReadConfigToml(".", true)
+
+	d := &Deployment{name: "liar"}
+	meta := d.GenerateDeployment(false).Metadata.(map[string]interface{})
+	labels := meta["labels"].(map[string]interface{})
+	assert.Equal(t, "true", labels["x-blaxel-auto-generated"])
+}


### PR DESCRIPTION
Fixes ENG-4738

## What

`bl deploy` rebuilt `metadata.labels` from scratch on every deploy, keeping only the two labels the CLI sets itself (`x-blaxel-auto-generated`, `x-blaxel-experimental`). Every other label on the resource was wiped, and `blaxel.toml` had no way to declare one.

So a label you set through the API survives until the next `bl deploy` quietly removes it.

## Why it matters

The platform reads labels at deploy time. I hit this on ENG-4721: `x-blaxel-builder` pins a single image to a builder, and it was gone before the build ever read it.

## Change

`blaxel.toml` takes a `[labels]` section:

```toml
type = "sandbox"
name = "my-sandbox"

[labels]
"x-blaxel-builder" = "sandbox"
team = "platform"
```

Those labels are applied alongside the CLI's own, which still win if a manifest tries to claim them.

## Test plan

- `go test ./cli/...` — two new tests: declared labels survive a deploy, and a manifest cannot override the CLI's own
- `make lint` — 0 issues
- Verified end to end against dev once built with `make build-dev`