### PR TITLE
Let blaxel.toml configure the build environment

### DIFF
--- a/cli/build_labels_test.go
+++ b/cli/build_labels_test.go
@@ -12,9 +12,6 @@ import (
 // that runs early enough, so a value that fails to become one is a value the
 // build never sees.
 func TestBuildSizesBecomeLabels(t *testing.T) {
-	zero := 0
-	big := 40960
-
 	for _, c := range []struct {
 		name  string
 		build *core.BuildConfig
@@ -24,27 +21,31 @@ func TestBuildSizesBecomeLabels(t *testing.T) {
 		{"no sizes declared", &core.BuildConfig{}, map[string]string{}},
 		{
 			"memory only",
-			&core.BuildConfig{Memory: 16384},
+			&core.BuildConfig{MemoryMb: 16384},
 			map[string]string{"x-blaxel-build-memory": "16384"},
 		},
 		{
-			// 0 is a request, not an absence: no disk, build in memory. Treating
-			// it as unset would silently give back the default scratch.
-			"scratch zero asks for an in-memory build",
-			&core.BuildConfig{Scratch: &zero},
-			map[string]string{"x-blaxel-build-scratch": "0"},
+			// No volume is the default, so absence carries nothing at all.
+			"no volume declared means an in-memory build",
+			&core.BuildConfig{MemoryMb: 8192},
+			map[string]string{"x-blaxel-build-memory": "8192"},
+		},
+		{
+			"experimental opts into the new builder",
+			&core.BuildConfig{Experimental: true},
+			map[string]string{"x-blaxel-builder": "sandbox"},
 		},
 		{
 			"both",
-			&core.BuildConfig{Memory: 16384, Scratch: &big},
+			&core.BuildConfig{MemoryMb: 16384, VolumeMb: 60000},
 			map[string]string{
-				"x-blaxel-build-memory":  "16384",
-				"x-blaxel-build-scratch": "40960",
+				"x-blaxel-build-memory": "16384",
+				"x-blaxel-build-volume": "60000",
 			},
 		},
 	} {
 		t.Run(c.name, func(t *testing.T) {
-			got := buildSizeLabels(c.build)
+			got := buildLabels(c.build)
 			if len(got) != len(c.want) {
 				t.Fatalf("got %v, want %v", got, c.want)
 			}

--- a/cli/build_labels_test.go
+++ b/cli/build_labels_test.go
@@ -90,3 +90,27 @@ func TestBuildLabelsAreTheSameOnBothSidesOfTheUpload(t *testing.T) {
 		t.Errorf("a project with no [build] section produced %v", got)
 	}
 }
+
+// The two upload paths are signed differently, and sending a header the URL was
+// not signed for fails the upload outright. push gets a URL signed with the
+// [build] choices; deploy gets its URL from the resource endpoint, which signs
+// none — so reading the metadata from global config, as a first version did,
+// broke every deploy of a project that declared a [build] section.
+func TestUploadOnlySendsMetadataItWasGiven(t *testing.T) {
+	deploy := &Deployment{}
+	if len(deploy.uploadMetadata) != 0 {
+		t.Errorf("a deploy must send no metadata, got %v", deploy.uploadMetadata)
+	}
+
+	push := &Deployment{}
+	signed := buildLabels(&core.BuildConfig{Experimental: true, MemoryMb: 8192})
+	push.WithUploadMetadata(signed)
+	if len(push.uploadMetadata) != len(signed) {
+		t.Fatalf("push carries %v, signed %v", push.uploadMetadata, signed)
+	}
+	for k, v := range signed {
+		if push.uploadMetadata[k] != v {
+			t.Errorf("%s = %q, signed %q", k, push.uploadMetadata[k], v)
+		}
+	}
+}

--- a/cli/build_labels_test.go
+++ b/cli/build_labels_test.go
@@ -1,12 +1,16 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/blaxel-ai/toolkit/cli/core"
 )
 
-// [build] memory and scratch cannot reach the builder the way [build] slim
+// [build] memoryMb and volumeMb cannot reach the builder the way [build] slim
 // does: slim is read inside the build environment, while these two size that
 // environment and must be known before it exists. Labels are the only channel
 // that runs early enough, so a value that fails to become one is a value the
@@ -91,26 +95,275 @@ func TestBuildLabelsAreTheSameOnBothSidesOfTheUpload(t *testing.T) {
 	}
 }
 
-// The two upload paths are signed differently, and sending a header the URL was
-// not signed for fails the upload outright. push gets a URL signed with the
-// [build] choices; deploy gets its URL from the resource endpoint, which signs
-// none — so reading the metadata from global config, as a first version did,
-// broke every deploy of a project that declared a [build] section.
+// Push and source-building deploys sign the selected labels into their upload
+// URLs, then repeat them as x-amz-meta-* headers. Metadata is set explicitly
+// through WithUploadMetadata so Upload never reads global config: a zero-value
+// Deployment carries nothing until its caller opts in.
 func TestUploadOnlySendsMetadataItWasGiven(t *testing.T) {
-	deploy := &Deployment{}
-	if len(deploy.uploadMetadata) != 0 {
-		t.Errorf("a deploy must send no metadata, got %v", deploy.uploadMetadata)
+	bare := &Deployment{}
+	if len(bare.uploadMetadata) != 0 {
+		t.Errorf("a bare Deployment must carry no metadata until WithUploadMetadata is called, got %v", bare.uploadMetadata)
 	}
 
-	push := &Deployment{}
+	configured := &Deployment{}
 	signed := buildLabels(&core.BuildConfig{Experimental: true, MemoryMb: 8192})
-	push.WithUploadMetadata(signed)
-	if len(push.uploadMetadata) != len(signed) {
-		t.Fatalf("push carries %v, signed %v", push.uploadMetadata, signed)
+	configured.WithUploadMetadata(signed)
+	if len(configured.uploadMetadata) != len(signed) {
+		t.Fatalf("configured deployment carries %v, signed %v", configured.uploadMetadata, signed)
 	}
 	for k, v := range signed {
-		if push.uploadMetadata[k] != v {
-			t.Errorf("%s = %q, signed %q", k, push.uploadMetadata[k], v)
+		if configured.uploadMetadata[k] != v {
+			t.Errorf("%s = %q, signed %q", k, configured.uploadMetadata[k], v)
 		}
 	}
+}
+
+func TestGenerateDeploymentBuildLabelsOnlyWhenBuildRuns(t *testing.T) {
+	server := mockServer(t, map[string]interface{}{
+		"GET /agents/": map[string]interface{}{
+			"metadata": map[string]interface{}{"name": "build-label-test"},
+			"spec": map[string]interface{}{
+				"runtime": map[string]interface{}{"image": "registry.blaxel.ai/test-workspace/build-label-test:existing"},
+			},
+		},
+	})
+	defer server.Close()
+	setupMockClient(t, server.URL)
+
+	for _, test := range []struct {
+		name       string
+		resource   string
+		image      string
+		skipBuild  bool
+		wantLabels bool
+	}{
+		{name: "source build", resource: "agent", wantLabels: true},
+		{name: "skip build", resource: "agent", skipBuild: true, wantLabels: false},
+		{name: "prebuilt image", resource: "agent", image: "docker.io/example/prebuilt:latest", wantLabels: false},
+		{name: "volume template upload", resource: "volume-template", wantLabels: false},
+		{name: "volume template upload with skip build", resource: "volume-template", skipBuild: true, wantLabels: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			config := "name = \"build-label-test\"\n" +
+				"type = \"" + test.resource + "\"\n"
+			if test.image != "" {
+				config += "image = \"" + test.image + "\"\n"
+			}
+			config += `
+[build]
+experimental = true
+memoryMb = 8192
+volumeMb = 30000
+`
+			if err := os.WriteFile(filepath.Join(dir, "blaxel.toml"), []byte(config), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			cwd, err := os.Getwd()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chdir(dir); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				_ = os.Chdir(cwd)
+				core.ResetConfig()
+			})
+
+			core.ResetConfig()
+			core.ReadConfigToml(".", true)
+			result := (&Deployment{name: "build-label-test"}).GenerateDeployment(test.skipBuild)
+			metadata := result.Metadata.(map[string]interface{})
+			labels := metadata["labels"].(map[string]interface{})
+
+			want := map[string]string{
+				"x-blaxel-builder":      "sandbox",
+				"x-blaxel-build-memory": "8192",
+				"x-blaxel-build-volume": "30000",
+			}
+			for name, value := range want {
+				got, ok := labels[name]
+				if test.wantLabels && (!ok || got != value) {
+					t.Errorf("%s = %q, want %q", name, got, value)
+				}
+				if !test.wantLabels && ok {
+					t.Errorf("%s = %q, want label omitted when no build runs", name, got)
+				}
+			}
+		})
+	}
+}
+
+func TestDeployUploadMetadataUsesFinalGeneratedLabels(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		config       string
+		experimental bool
+		wantFinal    map[string]string
+		wantUpload   map[string]string
+	}{
+		{
+			name: "legacy manual builder label is retained",
+			config: `
+[labels]
+"x-blaxel-builder" = "legacy"
+`,
+			wantFinal:  map[string]string{"x-blaxel-builder": "legacy"},
+			wantUpload: map[string]string{"x-blaxel-builder": "legacy"},
+		},
+		{
+			name:         "deploy experimental label is sent",
+			experimental: true,
+			wantFinal:    map[string]string{"x-blaxel-experimental": "true"},
+			wantUpload:   map[string]string{"x-blaxel-experimental": "true"},
+		},
+		{
+			name: "ordinary resource label is excluded",
+			config: `
+[labels]
+team = "platform"
+`,
+			wantFinal:  map[string]string{"team": "platform"},
+			wantUpload: nil,
+		},
+		{
+			name: "generated build label overrides manual value",
+			config: `
+[labels]
+"x-blaxel-build-memory" = "manual"
+
+[build]
+memoryMb = 8192
+`,
+			wantFinal:  map[string]string{"x-blaxel-build-memory": "8192"},
+			wantUpload: map[string]string{"x-blaxel-build-memory": "8192"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result, config := generateBuildLabelDeployment(t, test.config, test.experimental, false)
+			labels := buildLabelTestResultLabels(t, result)
+			for name, value := range test.wantFinal {
+				if got := labels[name]; got != value {
+					t.Errorf("final label %s = %q, want %q", name, got, value)
+				}
+			}
+
+			got := deployUploadMetadata(result, config, false)
+			if !reflect.DeepEqual(got, test.wantUpload) {
+				t.Errorf("upload metadata = %v, want %v", got, test.wantUpload)
+			}
+		})
+	}
+}
+
+func TestDeployUploadMetadataFiltersLabelValues(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		labels map[string]interface{}
+		want   map[string]string
+	}{
+		{
+			name:   "ordinary label",
+			labels: map[string]interface{}{"team": "platform"},
+			want:   nil,
+		},
+		{
+			name:   "empty allowed label",
+			labels: map[string]interface{}{"x-blaxel-builder": ""},
+			want:   nil,
+		},
+		{
+			name:   "65 byte allowed label",
+			labels: map[string]interface{}{"x-blaxel-builder": strings.Repeat("a", 65)},
+			want:   nil,
+		},
+		{
+			name:   "64 byte allowed label",
+			labels: map[string]interface{}{"x-blaxel-builder": strings.Repeat("a", 64)},
+			want:   map[string]string{"x-blaxel-builder": strings.Repeat("a", 64)},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result := core.Result{Metadata: map[string]interface{}{"labels": test.labels}}
+			got := deployUploadMetadata(result, core.Config{Type: "agent"}, false)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("upload metadata = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestDeployUploadMetadataReturnsNilWithoutSourceBuild(t *testing.T) {
+	result := core.Result{Metadata: map[string]interface{}{
+		"labels": map[string]interface{}{"x-blaxel-builder": "sandbox"},
+	}}
+	for _, test := range []struct {
+		name      string
+		config    core.Config
+		skipBuild bool
+	}{
+		{
+			name:   "prebuilt image",
+			config: core.Config{Type: "agent", Image: "docker.io/example/prebuilt:latest"},
+		},
+		{
+			name:      "skip build",
+			config:    core.Config{Type: "agent"},
+			skipBuild: true,
+		},
+		{
+			name:   "volume template",
+			config: core.Config{Type: "volume-template"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := deployUploadMetadata(result, test.config, test.skipBuild); got != nil {
+				t.Errorf("upload metadata = %v, want nil", got)
+			}
+		})
+	}
+}
+
+func generateBuildLabelDeployment(t *testing.T, extraConfig string, experimental, skipBuild bool) (core.Result, core.Config) {
+	t.Helper()
+	dir := t.TempDir()
+	config := `name = "build-label-test"
+type = "agent"
+` + extraConfig
+	if err := os.WriteFile(filepath.Join(dir, "blaxel.toml"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+		core.ResetConfig()
+	})
+
+	core.ResetConfig()
+	core.ReadConfigToml(".", true)
+	configValue := core.GetConfig()
+	result := (&Deployment{name: "build-label-test", experimental: experimental}).GenerateDeployment(skipBuild)
+	return result, configValue
+}
+
+func buildLabelTestResultLabels(t *testing.T, result core.Result) map[string]interface{} {
+	t.Helper()
+	metadata, ok := result.Metadata.(map[string]interface{})
+	if !ok {
+		t.Fatalf("metadata has type %T, want map", result.Metadata)
+	}
+	labels, ok := metadata["labels"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("metadata.labels has type %T, want map", metadata["labels"])
+	}
+	return labels
 }

--- a/cli/build_labels_test.go
+++ b/cli/build_labels_test.go
@@ -57,3 +57,36 @@ func TestBuildSizesBecomeLabels(t *testing.T) {
 		})
 	}
 }
+
+// `bl push` builds an image without creating a deployment, so there is no
+// resource record for a label to live on. The choices travel on the uploaded
+// object instead: the platform signs them into the presigned URL and the upload
+// repeats them as x-amz-meta-* headers. The two must agree exactly — a header
+// the signature did not cover is rejected as a mismatch, which is what makes
+// this a security boundary rather than a convenience.
+func TestBuildLabelsAreTheSameOnBothSidesOfTheUpload(t *testing.T) {
+	build := &core.BuildConfig{Experimental: true, MemoryMb: 16384, VolumeMb: 60000}
+
+	// What POST /images asks the platform to sign.
+	signed := buildLabels(build)
+	// What Upload puts on the wire, derived from the same source.
+	sent := map[string]string{}
+	for name, value := range buildLabels(build) {
+		sent["x-amz-meta-"+name] = value
+	}
+
+	if len(signed) != len(sent) {
+		t.Fatalf("signed %d labels but sent %d headers", len(signed), len(sent))
+	}
+	for name, value := range signed {
+		if got := sent["x-amz-meta-"+name]; got != value {
+			t.Errorf("header for %s = %q, signed %q", name, got, value)
+		}
+	}
+
+	// A project that declares nothing must sign nothing and send nothing, so an
+	// ordinary push is unchanged.
+	if got := buildLabels(nil); len(got) != 0 {
+		t.Errorf("a project with no [build] section produced %v", got)
+	}
+}

--- a/cli/build_size_labels_test.go
+++ b/cli/build_size_labels_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/blaxel-ai/toolkit/cli/core"
+)
+
+// [build] memory and scratch cannot reach the builder the way [build] slim
+// does: slim is read inside the build environment, while these two size that
+// environment and must be known before it exists. Labels are the only channel
+// that runs early enough, so a value that fails to become one is a value the
+// build never sees.
+func TestBuildSizesBecomeLabels(t *testing.T) {
+	zero := 0
+	big := 40960
+
+	for _, c := range []struct {
+		name  string
+		build *core.BuildConfig
+		want  map[string]string
+	}{
+		{"unset leaves it to the platform", nil, map[string]string{}},
+		{"no sizes declared", &core.BuildConfig{}, map[string]string{}},
+		{
+			"memory only",
+			&core.BuildConfig{Memory: 16384},
+			map[string]string{"x-blaxel-build-memory": "16384"},
+		},
+		{
+			// 0 is a request, not an absence: no disk, build in memory. Treating
+			// it as unset would silently give back the default scratch.
+			"scratch zero asks for an in-memory build",
+			&core.BuildConfig{Scratch: &zero},
+			map[string]string{"x-blaxel-build-scratch": "0"},
+		},
+		{
+			"both",
+			&core.BuildConfig{Memory: 16384, Scratch: &big},
+			map[string]string{
+				"x-blaxel-build-memory":  "16384",
+				"x-blaxel-build-scratch": "40960",
+			},
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			got := buildSizeLabels(c.build)
+			if len(got) != len(c.want) {
+				t.Fatalf("got %v, want %v", got, c.want)
+			}
+			for k, v := range c.want {
+				if got[k] != v {
+					t.Errorf("%s = %q, want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}

--- a/cli/core/config.go
+++ b/cli/core/config.go
@@ -274,6 +274,16 @@ type Package struct {
 // BuildConfig represents the [build] section of blaxel.toml
 type BuildConfig struct {
 	Args map[string]string `toml:"args,omitempty"`
+	// Memory is the RAM in MB given to the environment the image is built in,
+	// not to the deployed workload. Unset uses the platform default.
+	Memory int `toml:"memory,omitempty"`
+	// Scratch is the disk in MB given to the build for its intermediate layers.
+	// A build writes roughly three times the final image size there.
+	//
+	// 0 is meaningful and different from unset: it asks for no disk at all, so
+	// the build runs in memory. That is faster and fine for most images, but it
+	// then shares Memory above — a large image needs a real scratch.
+	Scratch *int `toml:"scratch,omitempty"`
 }
 
 // readConfigToml reads the config.toml file and upgrade config according to content

--- a/cli/core/config.go
+++ b/cli/core/config.go
@@ -274,16 +274,19 @@ type Package struct {
 // BuildConfig represents the [build] section of blaxel.toml
 type BuildConfig struct {
 	Args map[string]string `toml:"args,omitempty"`
-	// Memory is the RAM in MB given to the environment the image is built in,
-	// not to the deployed workload. Unset uses the platform default.
-	Memory int `toml:"memory,omitempty"`
-	// Scratch is the disk in MB given to the build for its intermediate layers.
-	// A build writes roughly three times the final image size there.
+	// Experimental opts this project into the new build system. It is the one
+	// setting here that changes which builder runs, rather than how it is sized.
+	Experimental bool `toml:"experimental,omitempty"`
+	// MemoryMb is the RAM given to the environment the image is built in, not to
+	// the deployed workload. Unset uses the platform default.
+	MemoryMb int `toml:"memoryMb,omitempty"`
+	// VolumeMb attaches a disk of that size to the build for its intermediate
+	// layers. Unset means no disk at all and the build runs in memory, which is
+	// faster and enough for most images.
 	//
-	// 0 is meaningful and different from unset: it asks for no disk at all, so
-	// the build runs in memory. That is faster and fine for most images, but it
-	// then shares Memory above — a large image needs a real scratch.
-	Scratch *int `toml:"scratch,omitempty"`
+	// Set it when the image is large: a build writes roughly three times the
+	// final image size, and without a disk that comes out of MemoryMb.
+	VolumeMb int `toml:"volumeMb,omitempty"`
 }
 
 // readConfigToml reads the config.toml file and upgrade config according to content

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -363,9 +363,14 @@ type Deployment struct {
 	experimental           bool
 	dockerConfigJSON       []byte
 	buildEnvContent        []byte
-	timeout                time.Duration
-	timeoutExplicit        bool
-	skipBuild              bool
+	// uploadMetadata is the object metadata the presigned URL was signed for.
+	// Empty on the deploy path, whose URL comes from the resource endpoint and
+	// carries no metadata; set by push, whose URL is signed with the [build]
+	// choices because that command creates no resource record to hold them.
+	uploadMetadata  map[string]string
+	timeout         time.Duration
+	timeoutExplicit bool
+	skipBuild       bool
 }
 
 // buildLabels turns blaxel.toml's [build] section into resource labels.
@@ -2022,6 +2027,12 @@ func (d *Deployment) UploadWithRetry(url string, refreshURL func() (string, erro
 	return lastErr
 }
 
+// WithUploadMetadata declares the object metadata the presigned URL was signed
+// for. It must match exactly: extra, missing or altered values fail the upload.
+func (d *Deployment) WithUploadMetadata(metadata map[string]string) {
+	d.uploadMetadata = metadata
+}
+
 func (d *Deployment) Upload(url string) error {
 	// Open the archive file
 	archiveFile, err := os.Open(d.archive.Name())
@@ -2063,12 +2074,12 @@ func (d *Deployment) Upload(url string) error {
 		req.Header.Set("Content-Type", "application/zip")
 	}
 
-	// The build choices from [build] are part of the URL's signature, so these
-	// headers must match exactly what the platform signed — sending none when it
-	// signed some, or the wrong value, is rejected as a signature mismatch. This
-	// is the only channel that reaches a `bl push` build: that command creates no
-	// resource record for a label to live on.
-	for name, value := range buildLabels(config.Build) {
+	// Only what the caller says was signed. These headers are part of the URL's
+	// signature, so sending one the platform did not sign is rejected outright —
+	// reading them from the global config instead would have broken every
+	// `bl deploy` of a project with a [build] section, because that path gets its
+	// URL from the resource endpoint, which signs nothing.
+	for name, value := range d.uploadMetadata {
 		req.Header.Set("x-amz-meta-"+name, value)
 	}
 

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -364,9 +364,8 @@ type Deployment struct {
 	dockerConfigJSON       []byte
 	buildEnvContent        []byte
 	// uploadMetadata is the object metadata the presigned URL was signed for.
-	// Empty on the deploy path, whose URL comes from the resource endpoint and
-	// carries no metadata; set by push, whose URL is signed with the [build]
-	// choices because that command creates no resource record to hold them.
+	// Push and source-building deploys set it explicitly; uploads that do not
+	// start a build, such as volume templates, leave it empty.
 	uploadMetadata  map[string]string
 	timeout         time.Duration
 	timeoutExplicit bool
@@ -406,7 +405,60 @@ func buildLabels(build *core.BuildConfig) map[string]string {
 	return out
 }
 
+func deployBuildsSource(config core.Config, skipBuild bool) bool {
+	return config.Image == "" && !skipBuild && !core.IsVolumeTemplate(config.Type)
+}
+
+// deployBuildLabels returns build settings only when deploy will build source.
+// A pre-built image, --skip-build, and volume-template uploads do not start a
+// build, so persisting build-only labels on those resources would be misleading.
+func deployBuildLabels(config core.Config, skipBuild bool) map[string]string {
+	if !deployBuildsSource(config, skipBuild) {
+		return nil
+	}
+	return buildLabels(config.Build)
+}
+
+const maxBuildUploadLabelValue = 64
+
+// deployUploadMetadata mirrors the control plane's build-label filter over the
+// final generated resource labels. Reading the final labels keeps legacy manual
+// labels, CLI-owned labels, and [build] settings identical on both sides of the
+// signed upload.
+func deployUploadMetadata(result core.Result, config core.Config, skipBuild bool) map[string]string {
+	if !deployBuildsSource(config, skipBuild) {
+		return nil
+	}
+	metadata, ok := result.Metadata.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	labels, ok := metadata["labels"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	out := map[string]string{}
+	for _, name := range [...]string{
+		"x-blaxel-builder",
+		"x-blaxel-experimental",
+		"x-blaxel-build-memory",
+		"x-blaxel-build-volume",
+	} {
+		value, ok := labels[name].(string)
+		if !ok || value == "" || len(value) > maxBuildUploadLabelValue {
+			continue
+		}
+		out[name] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 func (d *Deployment) Generate(skipBuild bool) error {
+	d.skipBuild = skipBuild
 	if d.name == "" {
 		d.name = filepath.Base(filepath.Join(d.cwd, d.folder))
 	}
@@ -419,11 +471,14 @@ func (d *Deployment) Generate(skipBuild bool) error {
 		return fmt.Errorf("failed to seed cache: %w", err)
 	}
 
-	// Generate the blaxel deployment yaml
-	d.blaxelDeployments = []core.Result{d.GenerateDeployment(skipBuild)}
+	config := core.GetConfig()
+	// Generate the blaxel deployment yaml and retain the exact metadata the
+	// control plane will sign for a source build.
+	deployment := d.GenerateDeployment(skipBuild)
+	d.blaxelDeployments = []core.Result{deployment}
+	d.WithUploadMetadata(deployUploadMetadata(deployment, config, skipBuild))
 
 	// Volume-template needs archive even without build (for file upload)
-	config := core.GetConfig()
 	// Skip archive creation when a pre-built image is specified in blaxel.toml
 	if config.Image == "" && (!skipBuild || core.IsVolumeTemplate(config.Type)) {
 		// Create archive (tar for volume-template, zip for others)
@@ -853,7 +908,7 @@ func (d *Deployment) GenerateDeployment(skipBuild bool) core.Result {
 	for name, value := range config.Labels {
 		labels[name] = value
 	}
-	for name, value := range buildLabels(config.Build) {
+	for name, value := range deployBuildLabels(config, skipBuild) {
 		labels[name] = value
 	}
 	if config.Image == "" && (!skipBuild || core.IsVolumeTemplate(config.Type)) {
@@ -1035,11 +1090,6 @@ func (d *Deployment) Apply() error {
 				fmt.Printf("Uploading %s...\n", resourceLabel)
 			}
 
-			// The platform signs the [build] labels it received on the resource into
-			// this URL, so the upload has to repeat them. They stay labels on the
-			// wire — build settings do not belong in the resource's public schema —
-			// but they are signed, so a client cannot alter what the build sees.
-			d.WithUploadMetadata(buildLabels(core.GetConfig().Build))
 			err := d.UploadWithRetry(result.Result.UploadURL, func() (string, error) {
 				newResults, err := ApplyResources(d.blaxelDeployments)
 				if err != nil {
@@ -1403,7 +1453,6 @@ func (d *Deployment) deployResourceInteractive(resource *deploy.Resource, model 
 			model.AddBuildLog(idx, "Uploading code to registry...")
 		}
 
-		d.WithUploadMetadata(buildLabels(core.GetConfig().Build))
 		err := d.UploadWithRetry(applyResults[0].Result.UploadURL, func() (string, error) {
 			newResults, applyErr := ApplyResources([]core.Result{deployment})
 			if applyErr != nil {
@@ -2081,10 +2130,9 @@ func (d *Deployment) Upload(url string) error {
 	}
 
 	// Only what the caller says was signed. These headers are part of the URL's
-	// signature, so sending one the platform did not sign is rejected outright —
-	// reading them from the global config instead would have broken every
-	// `bl deploy` of a project with a [build] section, because that path gets its
-	// URL from the resource endpoint, which signs nothing.
+	// signature, so sending one the platform did not sign is rejected outright.
+	// Keeping this explicit also prevents non-build uploads from inheriting
+	// unrelated global build configuration.
 	for name, value := range d.uploadMetadata {
 		req.Header.Set("x-amz-meta-"+name, value)
 	}

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -1035,6 +1035,11 @@ func (d *Deployment) Apply() error {
 				fmt.Printf("Uploading %s...\n", resourceLabel)
 			}
 
+			// The platform signs the [build] labels it received on the resource into
+			// this URL, so the upload has to repeat them. They stay labels on the
+			// wire — build settings do not belong in the resource's public schema —
+			// but they are signed, so a client cannot alter what the build sees.
+			d.WithUploadMetadata(buildLabels(core.GetConfig().Build))
 			err := d.UploadWithRetry(result.Result.UploadURL, func() (string, error) {
 				newResults, err := ApplyResources(d.blaxelDeployments)
 				if err != nil {
@@ -1398,6 +1403,7 @@ func (d *Deployment) deployResourceInteractive(resource *deploy.Resource, model 
 			model.AddBuildLog(idx, "Uploading code to registry...")
 		}
 
+		d.WithUploadMetadata(buildLabels(core.GetConfig().Build))
 		err := d.UploadWithRetry(applyResults[0].Result.UploadURL, func() (string, error) {
 			newResults, applyErr := ApplyResources([]core.Result{deployment})
 			if applyErr != nil {

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -368,6 +368,32 @@ type Deployment struct {
 	skipBuild              bool
 }
 
+// buildSizeLabels turns blaxel.toml's [build] memory and scratch into labels.
+//
+// They travel as labels because the control plane needs them before the build
+// environment exists — too early for anything to have read blaxel.toml. That is
+// what separates them from [build] slim, which is read inside that environment
+// and can stay in the manifest.
+//
+// Nothing is clamped: the platform enforces the workspace's quotas, and its
+// refusal names the plan. A client-side limit would only duplicate the numbers
+// and replace a precise message with a guess.
+func buildSizeLabels(build *core.BuildConfig) map[string]string {
+	out := map[string]string{}
+	if build == nil {
+		return out
+	}
+	if build.Memory > 0 {
+		out["x-blaxel-build-memory"] = strconv.Itoa(build.Memory)
+	}
+	// Explicitly set, 0 included — 0 asks for a build with no disk, in memory.
+	// Treating it as unset would hand back the default scratch instead.
+	if build.Scratch != nil && *build.Scratch >= 0 {
+		out["x-blaxel-build-scratch"] = strconv.Itoa(*build.Scratch)
+	}
+	return out
+}
+
 func (d *Deployment) Generate(skipBuild bool) error {
 	if d.name == "" {
 		d.name = filepath.Base(filepath.Join(d.cwd, d.folder))
@@ -813,6 +839,9 @@ func (d *Deployment) GenerateDeployment(skipBuild bool) core.Result {
 	// anything the user asked for has to survive the deploy. Without this the
 	// map is rebuilt from scratch on every deploy and every other label is lost.
 	for name, value := range config.Labels {
+		labels[name] = value
+	}
+	for name, value := range buildSizeLabels(config.Build) {
 		labels[name] = value
 	}
 	if config.Image == "" && (!skipBuild || core.IsVolumeTemplate(config.Type)) {

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -368,7 +368,7 @@ type Deployment struct {
 	skipBuild              bool
 }
 
-// buildSizeLabels turns blaxel.toml's [build] memory and scratch into labels.
+// buildLabels turns blaxel.toml's [build] section into resource labels.
 //
 // They travel as labels because the control plane needs them before the build
 // environment exists — too early for anything to have read blaxel.toml. That is
@@ -378,18 +378,25 @@ type Deployment struct {
 // Nothing is clamped: the platform enforces the workspace's quotas, and its
 // refusal names the plan. A client-side limit would only duplicate the numbers
 // and replace a precise message with a guess.
-func buildSizeLabels(build *core.BuildConfig) map[string]string {
+func buildLabels(build *core.BuildConfig) map[string]string {
 	out := map[string]string{}
 	if build == nil {
 		return out
 	}
-	if build.Memory > 0 {
-		out["x-blaxel-build-memory"] = strconv.Itoa(build.Memory)
+	// Distinct from the CLI's --experimental, which marks the deployed resource.
+	// This one selects the builder, and only opts in: a project that does not ask
+	// keeps whatever the platform rolls out, so removing the line never pins it
+	// back to the old one.
+	if build.Experimental {
+		out["x-blaxel-builder"] = "sandbox"
 	}
-	// Explicitly set, 0 included — 0 asks for a build with no disk, in memory.
-	// Treating it as unset would hand back the default scratch instead.
-	if build.Scratch != nil && *build.Scratch >= 0 {
-		out["x-blaxel-build-scratch"] = strconv.Itoa(*build.Scratch)
+	if build.MemoryMb > 0 {
+		out["x-blaxel-build-memory"] = strconv.Itoa(build.MemoryMb)
+	}
+	// Absent means no disk, which is the default, so only a positive size needs
+	// carrying. That is what lets both stay plain ints rather than pointers.
+	if build.VolumeMb > 0 {
+		out["x-blaxel-build-volume"] = strconv.Itoa(build.VolumeMb)
 	}
 	return out
 }
@@ -841,7 +848,7 @@ func (d *Deployment) GenerateDeployment(skipBuild bool) core.Result {
 	for name, value := range config.Labels {
 		labels[name] = value
 	}
-	for name, value := range buildSizeLabels(config.Build) {
+	for name, value := range buildLabels(config.Build) {
 		labels[name] = value
 	}
 	if config.Image == "" && (!skipBuild || core.IsVolumeTemplate(config.Type)) {

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -2063,6 +2063,15 @@ func (d *Deployment) Upload(url string) error {
 		req.Header.Set("Content-Type", "application/zip")
 	}
 
+	// The build choices from [build] are part of the URL's signature, so these
+	// headers must match exactly what the platform signed — sending none when it
+	// signed some, or the wrong value, is rejected as a signature mismatch. This
+	// is the only channel that reaches a `bl push` build: that command creates no
+	// resource record for a label to live on.
+	for name, value := range buildLabels(config.Build) {
+		req.Header.Set("x-amz-meta-"+name, value)
+	}
+
 	// Perform the request
 	client := &http.Client{}
 	resp, err := client.Do(req)

--- a/cli/push.go
+++ b/cli/push.go
@@ -37,6 +37,11 @@ type createImageRequest struct {
 	Generation   string `json:"generation,omitempty"`
 	Image        string `json:"image,omitempty"`
 	DockerConfig string `json:"dockerConfig,omitempty"`
+	// Labels carries blaxel.toml's [build] choices. The platform signs them into
+	// the upload URL, and Upload sends matching headers — that round trip is what
+	// gets them to a build started by `bl push`, which creates no resource
+	// record a label could otherwise ride on.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // createImageResponse is the response body from POST /images.
@@ -344,6 +349,7 @@ For private registries, supply credentials via --registry-cred or --docker-confi
 					Name:         name,
 					ResourceType: resourceType,
 					Generation:   generation,
+					Labels:       buildLabels(core.GetConfig().Build),
 				}
 
 				var httpResponse *http.Response

--- a/cli/push.go
+++ b/cli/push.go
@@ -375,6 +375,8 @@ For private registries, supply credentials via --registry-cred or --docker-confi
 
 				// Upload the archive to the presigned URL
 				fmt.Println("Uploading source code...")
+				// The platform signed exactly these into the URL above.
+				deployment.WithUploadMetadata(reqBody.Labels)
 				err = deployment.UploadWithRetry(uploadURL, func() (string, error) {
 					var retryResp *http.Response
 					var retryBody createImageResponse


### PR DESCRIPTION
Fixes ENG-4886

## What

Adds three settings under `[build]` in `blaxel.toml`:

```toml
[build]
experimental = true   # use the new build system
memoryMb = 16384      # RAM for the build
volumeMb = 60000      # disk for the build; omit it to build in memory
```

## Why

The platform sizes the build environment from one default. The person deploying knows what they are building, so a project that needs a big build can now say so instead of failing on a default meant for the average case.

`experimental` replaces hand-writing an internal label:

```toml
[labels]
"x-blaxel-builder" = "sandbox"   # before
```

Everything build-related now lives in one place, and the label goes back to being an implementation detail.

## Notes for review

- **These become labels**, unlike `[build] slim`. The control plane needs them *before* the build environment exists, which is too early for anything to have read `blaxel.toml`. Labels are the channel that runs early enough.
- **Nothing is clamped here.** The platform enforces the workspace's quotas and its refusal names the plan; a client-side limit would duplicate the numbers and give a vaguer message.
- **`experimental` only opts in.** A project that omits it follows whatever the platform rolls out, so deleting the line never pins it back to the old builder.
- Needs the matching control-plane change (blaxel-ai/controlplane#5130) to have any effect.

## Test plan

- `go test ./cli/` — new table test covers each field, both set, and neither.
- Deployed end to end against dev: a project with `[build] experimental = true` builds on the new builder; `volumeMb` omitted builds in memory and the sandbox comes up.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> New commit adds `WithUploadMetadata(buildLabels(...))` to both deploy upload paths (`Apply` and `deployResourceInteractive`), aligning deploy with push now that the control plane signs build labels into deploy URLs too.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit d3c78062f8b435316187142418bc4c8cca6db1b3.</sup>
<!-- /MENDRAL_SUMMARY -->