### PR TITLE
fix(cli): classify empty image tags as expected

### DIFF
--- a/cli/images.go
+++ b/cli/images.go
@@ -193,11 +193,21 @@ func getImageLatest(resourceType, imageName string) {
 		core.ExitWithError(err)
 	}
 
-	tags := imageResult.Spec.Tags
-	if len(tags) == 0 {
-		err := fmt.Errorf("no tags found for image %s/%s", resourceType, imageName)
+	latestTag, err := latestImageTag(resourceType, imageName, imageResult.Spec.Tags)
+	if err != nil {
 		fmt.Println(err)
 		core.ExitWithError(err)
+	}
+
+	fmt.Printf("%s/%s:%s\n", resourceType, imageName, latestTag)
+}
+
+func latestImageTag(resourceType, imageName string, tags []blaxel.ImageSpecTag) (string, error) {
+	if len(tags) == 0 {
+		return "", core.MarkExpectedError(
+			fmt.Errorf("no tags found for image %s/%s", resourceType, imageName),
+			core.CLIErrorNotFound,
+		)
 	}
 
 	// Sort tags by createdAt descending to find the most recent
@@ -205,7 +215,7 @@ func getImageLatest(resourceType, imageName string) {
 		return tags[i].CreatedAt > tags[j].CreatedAt
 	})
 
-	fmt.Printf("%s/%s:%s\n", resourceType, imageName, tags[0].Name)
+	return tags[0].Name, nil
 }
 
 func getImage(resourceType, imageName, tag string) {

--- a/cli/images_test.go
+++ b/cli/images_test.go
@@ -3,7 +3,10 @@ package cli
 import (
 	"testing"
 
+	blaxel "github.com/blaxel-ai/sdk-go"
+	"github.com/blaxel-ai/toolkit/cli/core"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseImageRef(t *testing.T) {
@@ -126,6 +129,26 @@ func TestGetImagesCmd(t *testing.T) {
 	assert.NotNil(t, latestFlag)
 	assert.Equal(t, "false", latestFlag.DefValue)
 	assert.Contains(t, latestFlag.Usage, "most recent tag")
+}
+
+func TestLatestImageTag(t *testing.T) {
+	tags := []blaxel.ImageSpecTag{
+		{Name: "older", CreatedAt: "2026-01-02T00:00:00Z"},
+		{Name: "newer", CreatedAt: "2026-01-03T00:00:00Z"},
+	}
+
+	latest, err := latestImageTag("sandbox", "my-image", tags)
+	require.NoError(t, err)
+	assert.Equal(t, "newer", latest)
+}
+
+func TestLatestImageTagWithoutTagsIsExpectedNotFound(t *testing.T) {
+	latest, err := latestImageTag("sandbox", "my-image", nil)
+
+	require.Error(t, err)
+	assert.Empty(t, latest)
+	assert.Equal(t, "no tags found for image sandbox/my-image", err.Error())
+	assert.True(t, core.IsExpectedCLIError(err))
 }
 
 func TestDeleteImagesCmd(t *testing.T) {


### PR DESCRIPTION
Fixes ENG-4996

## Summary

Classify an image response with no tags as an expected `CLIErrorNotFound` in `bl get image --latest`.

The existing user-facing message, exit code, and newest-tag selection are unchanged. The handled empty-tag path no longer reports as `CLIInternalError` in Sentry.

This replacement PR supersedes scope-blocked PR #376. PR #376 and its branch remain open and untouched.

## Root cause

Sentry issue CLI-38 recorded 989 production events in release `0.1.108`, all tagged `bl get image`, with the stack ending at `getImageLatest (.:200)`. That line was the unclassified `no tags found` branch.

## Reproduction

Before the fix, a disposable Sentry MockTransport run reported:

```
plain_events=1 marked_events_after_plain=1 plain_expected=false marked_expected=true
```

The error text was identical before and after classification.

## Changes

- Extract latest-tag selection into `latestImageTag`.
- Mark an empty tag list with `core.MarkExpectedError(..., core.CLIErrorNotFound)`.
- Add focused coverage for newest-tag sorting, exact error text, and expected classification.

## Scope

The branch is based directly on `origin/main` and changes exactly:

- `cli/images.go`
- `cli/images_test.go`

## Validation

- `go test ./cli -run 'TestLatestImageTag|TestGetImagesCmd' -count=1 -v`
- `go test ./cli/core -run 'TestMarkExpectedErrorPreservesLocalMessageAndCause|TestExpectedErrorsCreateNoSentryEvents' -count=1 -v`
- `go test ./... -count=1`
- `make lint` (0 issues)
- `go vet ./...`
- `go build ./...`

All passed.

## Residual

The fix is not deployed yet; CLI-38 remains unresolved in production until this PR is merged and released.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI error-classification change with no auth, data, or API contract changes; behavior for users stays the same aside from observability.
> 
> **Overview**
> **`bl get image --latest`** now routes tag selection through a new **`latestImageTag`** helper. When the API returns an image with **no tags**, that case is wrapped as an **expected `CLIErrorNotFound`** instead of surfacing as an internal CLI error—same user message and exit behavior, but **no Sentry noise** for this handled path.
> 
> New unit tests cover **newest-tag-by-`createdAt` sorting**, the **exact empty-tag error text**, and **`IsExpectedCLIError`** for the empty-tag branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21f7660f3c75563906167c27252971c3445e7a3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Extracts latest-tag selection into a standalone `latestImageTag` function and marks the empty-tags case with `core.MarkExpectedError(..., core.CLIErrorNotFound)` so it no longer surfaces as an internal error in Sentry. Adds unit tests for both the happy path and the empty-tags path.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 21f7660f3c75563906167c27252971c3445e7a3a.</sup>
<!-- /MENDRAL_SUMMARY -->